### PR TITLE
Refactor driver CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,7 @@ lint:
 
 vet:
 	@echo "go vet ."
-	@go vet $$(go list ./... | grep -v vendor/) ; if [ $$? -eq 1 ]; then \
-		echo ""; \
-		echo "Vet found suspicious constructs. Please check the reported constructs"; \
-		echo "and fix them if necessary before submitting the code for review."; \
-		exit 1; \
-	fi
+	@go vet ./...
 
 acceptance:
 	@echo "Starting acceptance tests..."


### PR DESCRIPTION
## Changes

Remove deprecated flags

Change some default values including `az`,` image`, `volume type`

Remove k8s-related security group creation

Assure all env vars is prefixed with `OS_`

Change default env var for `otc-subnet-id` to `OS_NETWORK_ID`

## Acceptance tests

```
=== RUN   TestDriver_SetConfigFromFlags
--- PASS: TestDriver_SetConfigFromFlags (0.00s)
=== RUN   TestDriver_Auth
--- PASS: TestDriver_Auth (2.15s)
=== RUN   TestDriver_Auth/default
    --- PASS: TestDriver_Auth/default (0.56s)
=== RUN   TestDriver_Auth/credentis
    --- PASS: TestDriver_Auth/credentis (0.46s)
=== RUN   TestDriver_Auth/ak/sk
    --- PASS: TestDriver_Auth/ak/sk (1.13s)
=== RUN   TestDriver_AuthCreds
--- PASS: TestDriver_AuthCreds (0.43s)
=== RUN   TestDriver_AuthAKSK
--- PASS: TestDriver_AuthAKSK (0.40s)
=== RUN   TestDriver_Create
--- PASS: TestDriver_Create (221.93s)
=== RUN   TestDriver_Create/default
    --- PASS: TestDriver_Create/default (107.29s)
=== RUN   TestDriver_Create/ak/sk
    --- PASS: TestDriver_Create/ak/sk (114.64s)
=== RUN   TestDriver_Start
--- PASS: TestDriver_Start (187.68s)
=== RUN   TestDriver_CreateWithExistingSecGroups
--- PASS: TestDriver_CreateWithExistingSecGroups (103.73s)
=== RUN   TestDriver_ExistingSSHKey
--- PASS: TestDriver_ExistingSSHKey (98.85s)
=== RUN   TestDriver_WithoutFloatingIP
--- PASS: TestDriver_WithoutFloatingIP (110.88s)
=== RUN   TestDriver_CreateWithUserData
--- PASS: TestDriver_CreateWithUserData (108.10s)
=== RUN   TestDriver_UserDataRaw
--- PASS: TestDriver_UserDataRaw (0.90s)
=== RUN   TestDriver_ResolveServerGroup
--- PASS: TestDriver_ResolveServerGroup (3.93s)
=== RUN   TestDriver_FaultyRemove
--- PASS: TestDriver_FaultyRemove (5.30s)
PASS

Process finished with exit code 0

```