### PR TITLE
Make `.editorconfig` standard for the project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,5 +3,29 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 
-[{*.go, go.mod}]
+[*.go]
 indent_style = tab
+ij_continuation_indent_size = 4
+ij_go_add_leading_space_to_comments = true
+ij_go_add_parentheses_for_single_import = false
+ij_go_call_parameters_new_line_after_left_paren = true
+ij_go_call_parameters_right_paren_on_new_line = true
+ij_go_call_parameters_wrap = off
+ij_go_fill_paragraph_width = 80
+ij_go_group_current_project_imports = true
+ij_go_group_stdlib_imports = true
+ij_go_import_sorting = gofmt
+ij_go_keep_indents_on_empty_lines = false
+ij_go_move_all_imports_in_one_declaration = true
+ij_go_move_all_stdlib_imports_in_one_group = true
+ij_go_remove_redundant_import_aliases = false
+ij_go_use_back_quotes_for_imports = false
+ij_go_wrap_comp_lit = off
+ij_go_wrap_comp_lit_newline_after_lbrace = true
+ij_go_wrap_comp_lit_newline_before_rbrace = true
+ij_go_wrap_func_params = off
+ij_go_wrap_func_params_newline_after_lparen = true
+ij_go_wrap_func_params_newline_before_rparen = true
+ij_go_wrap_func_result = off
+ij_go_wrap_func_result_newline_after_lparen = true
+ij_go_wrap_func_result_newline_before_rparen = true


### PR DESCRIPTION
Add `ij_` rules for `*.go` files