### PR TITLE
Fix flags and env vars

### DIFF
--- a/driver/flags.go
+++ b/driver/flags.go
@@ -68,9 +68,9 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "ACCESS_KEY_ID",
 		},
 		mcnflag.StringFlag{
-			Name:   "otc-access-key-key",
+			Name:   "otc-secret-access-key",
 			Usage:  "OpenTelekomCloud secret access key for AK/SK auth",
-			EnvVar: "ACCESS_KEY_SECRET",
+			EnvVar: "SECRET_ACCESS_KEY",
 		},
 		mcnflag.StringFlag{
 			Name:   "otc-availability-zone",
@@ -273,7 +273,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.Tags = strings.Split(tags, ",")
 	}
 	d.AccessKey = flags.String("otc-access-key-id")
-	d.SecretKey = flags.String("otc-access-key-key")
+	d.SecretKey = flags.String("otc-secret-access-key")
 
 	d.RootVolumeOpts = &services.DiskOpts{
 		SourceID: flags.String("otc-image-id"),

--- a/driver/flags.go
+++ b/driver/flags.go
@@ -63,14 +63,14 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Value:  defaultRegion,
 		},
 		mcnflag.StringFlag{
-			Name:   "otc-access-key-id",
+			Name:   "otc-access-key",
 			Usage:  "OpenTelekomCloud access key ID for AK/SK auth",
-			EnvVar: "OS_ACCESS_KEY_ID",
+			EnvVar: "OS_ACCESS_KEY",
 		},
 		mcnflag.StringFlag{
-			Name:   "otc-secret-access-key",
+			Name:   "otc-secret-key",
 			Usage:  "OpenTelekomCloud secret access key for AK/SK auth",
-			EnvVar: "OS_SECRET_ACCESS_KEY",
+			EnvVar: "OS_SECRET_KEY",
 		},
 		mcnflag.StringFlag{
 			Name:   "otc-availability-zone",
@@ -272,8 +272,8 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	if tags != "" {
 		d.Tags = strings.Split(tags, ",")
 	}
-	d.AccessKey = flags.String("otc-access-key-id")
-	d.SecretKey = flags.String("otc-secret-access-key")
+	d.AccessKey = flags.String("otc-access-key")
+	d.SecretKey = flags.String("otc-secret-key")
 
 	d.RootVolumeOpts = &services.DiskOpts{
 		SourceID: flags.String("otc-image-id"),

--- a/driver/flags.go
+++ b/driver/flags.go
@@ -58,19 +58,19 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.StringFlag{
 			Name:   "otc-region",
-			EnvVar: "REGION",
+			EnvVar: "OS_REGION",
 			Usage:  "OpenTelekomCloud region name",
 			Value:  defaultRegion,
 		},
 		mcnflag.StringFlag{
 			Name:   "otc-access-key-id",
 			Usage:  "OpenTelekomCloud access key ID for AK/SK auth",
-			EnvVar: "ACCESS_KEY_ID",
+			EnvVar: "OS_ACCESS_KEY_ID",
 		},
 		mcnflag.StringFlag{
 			Name:   "otc-secret-access-key",
 			Usage:  "OpenTelekomCloud secret access key for AK/SK auth",
-			EnvVar: "SECRET_ACCESS_KEY",
+			EnvVar: "OS_SECRET_ACCESS_KEY",
 		},
 		mcnflag.StringFlag{
 			Name:   "otc-availability-zone",
@@ -80,7 +80,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.StringFlag{
 			Name:   "otc-flavor-id",
-			EnvVar: "FLAVOR_ID",
+			EnvVar: "OS_FLAVOR_ID",
 			Usage:  "OpenTelekomCloud flavor id to use for the instance",
 		},
 		mcnflag.StringFlag{

--- a/driver/opentelekomcloud_test.go
+++ b/driver/opentelekomcloud_test.go
@@ -30,7 +30,7 @@ var (
 		"otc-vpc-name":    vpcName,
 		"otc-tags":        "machine,test",
 	}
-	testEnv = openstack.NewEnv("OTC_")
+	testEnv = openstack.NewEnv("OS_")
 )
 
 func newDriverFromFlags(driverFlags map[string]interface{}) (*Driver, error) {
@@ -89,10 +89,10 @@ func TestDriver_Auth(t *testing.T) {
 			"otc-password":     testEnv.GetEnv("PASSWORD"),
 		},
 		"ak/sk": {
-			"otc-access-key-id":  testEnv.GetEnv("ACCESS_KEY_ID"),
-			"otc-access-key-key": testEnv.GetEnv("ACCESS_KEY_SECRET"),
-			"otc-domain-name":    testEnv.GetEnv("DOMAIN_NAME"),
-			"otc-project-name":   testEnv.GetEnv("PROJECT_NAME"),
+			"otc-access-key-id":     testEnv.GetEnv("ACCESS_KEY_ID"),
+			"otc-secret-access-key": testEnv.GetEnv("SECRET_ACCESS_KEY"),
+			"otc-domain-name":       testEnv.GetEnv("DOMAIN_NAME"),
+			"otc-project-name":      testEnv.GetEnv("PROJECT_NAME"),
 		},
 	}
 	for name, flags := range testFlags {
@@ -104,7 +104,7 @@ func TestDriver_Auth(t *testing.T) {
 
 }
 
-func TestDriver_AuthCreds(t *testing.T) {
+func TestDriver_AuthCredentials(t *testing.T) {
 	_, err := newDriverFromFlags(
 		map[string]interface{}{
 			"otc-domain-name":  testEnv.GetEnv("DOMAIN_NAME"),
@@ -118,8 +118,8 @@ func TestDriver_AuthCreds(t *testing.T) {
 func TestDriver_AuthAKSK(t *testing.T) {
 	_, err := newDriverFromFlags(
 		map[string]interface{}{
-			"otc-access-key-id":  testEnv.GetEnv("ACCESS_KEY_ID"),
-			"otc-access-key-key": testEnv.GetEnv("ACCESS_KEY_SECRET"),
+			"otc-access-key-id":     testEnv.GetEnv("ACCESS_KEY_ID"),
+			"otc-secret-access-key": testEnv.GetEnv("SECRET_ACCESS_KEY"),
 		})
 	assert.NoError(t, err)
 }
@@ -128,13 +128,13 @@ func TestDriver_Create(t *testing.T) {
 	testFlags := map[string]map[string]interface{}{
 		"default": defaultFlags,
 		"ak/sk": {
-			"otc-access-key-id":  testEnv.GetEnv("ACCESS_KEY_ID"),
-			"otc-access-key-key": testEnv.GetEnv("ACCESS_KEY_SECRET"),
-			"otc-domain-name":    testEnv.GetEnv("DOMAIN_NAME"),
-			"otc-project-name":   testEnv.GetEnv("PROJECT_NAME"),
-			"otc-subnet-name":    defaultFlags["otc-subnet-name"],
-			"otc-vpc-name":       defaultFlags["otc-vpc-name"],
-			"otc-tags":           "machine,test",
+			"otc-access-key-id":     testEnv.GetEnv("ACCESS_KEY_ID"),
+			"otc-secret-access-key": testEnv.GetEnv("SECRET_ACCESS_KEY"),
+			"otc-domain-name":       testEnv.GetEnv("DOMAIN_NAME"),
+			"otc-project-name":      testEnv.GetEnv("PROJECT_NAME"),
+			"otc-subnet-name":       defaultFlags["otc-subnet-name"],
+			"otc-vpc-name":          defaultFlags["otc-vpc-name"],
+			"otc-tags":              "machine,test",
 		},
 	}
 
@@ -402,8 +402,8 @@ func TestDriver_ResolveServerGroup(t *testing.T) {
 }
 
 func TestDriver_FaultyRemove(t *testing.T) {
-	driver, derr := defaultDriver()
-	require.NoError(t, derr)
+	driver, dErr := defaultDriver()
+	require.NoError(t, dErr)
 	require.NoError(t, driver.initCompute())
 	require.NoError(t, driver.initNetwork())
 	require.NoError(t, driver.resolveIDs())

--- a/driver/opentelekomcloud_test.go
+++ b/driver/opentelekomcloud_test.go
@@ -104,26 +104,6 @@ func TestDriver_Auth(t *testing.T) {
 
 }
 
-func TestDriver_AuthCredentials(t *testing.T) {
-	_, err := newDriverFromFlags(
-		map[string]interface{}{
-			"otc-domain-name":  testEnv.GetEnv("DOMAIN_NAME"),
-			"otc-project-name": testEnv.GetEnv("PROJECT_NAME"),
-			"otc-username":     testEnv.GetEnv("USERNAME"),
-			"otc-password":     testEnv.GetEnv("PASSWORD"),
-		})
-	assert.NoError(t, err)
-}
-
-func TestDriver_AuthAKSK(t *testing.T) {
-	_, err := newDriverFromFlags(
-		map[string]interface{}{
-			"otc-access-key": testEnv.GetEnv("ACCESS_KEY"),
-			"otc-secret-key": testEnv.GetEnv("SECRET_KEY"),
-		})
-	assert.NoError(t, err)
-}
-
 func TestDriver_Create(t *testing.T) {
 	testFlags := map[string]map[string]interface{}{
 		"default": defaultFlags,

--- a/driver/opentelekomcloud_test.go
+++ b/driver/opentelekomcloud_test.go
@@ -89,10 +89,10 @@ func TestDriver_Auth(t *testing.T) {
 			"otc-password":     testEnv.GetEnv("PASSWORD"),
 		},
 		"ak/sk": {
-			"otc-access-key-id":     testEnv.GetEnv("ACCESS_KEY_ID"),
-			"otc-secret-access-key": testEnv.GetEnv("SECRET_ACCESS_KEY"),
-			"otc-domain-name":       testEnv.GetEnv("DOMAIN_NAME"),
-			"otc-project-name":      testEnv.GetEnv("PROJECT_NAME"),
+			"otc-access-key":   testEnv.GetEnv("ACCESS_KEY"),
+			"otc-secret-key":   testEnv.GetEnv("SECRET_KEY"),
+			"otc-domain-name":  testEnv.GetEnv("DOMAIN_NAME"),
+			"otc-project-name": testEnv.GetEnv("PROJECT_NAME"),
 		},
 	}
 	for name, flags := range testFlags {
@@ -118,8 +118,8 @@ func TestDriver_AuthCredentials(t *testing.T) {
 func TestDriver_AuthAKSK(t *testing.T) {
 	_, err := newDriverFromFlags(
 		map[string]interface{}{
-			"otc-access-key-id":     testEnv.GetEnv("ACCESS_KEY_ID"),
-			"otc-secret-access-key": testEnv.GetEnv("SECRET_ACCESS_KEY"),
+			"otc-access-key": testEnv.GetEnv("ACCESS_KEY"),
+			"otc-secret-key": testEnv.GetEnv("SECRET_KEY"),
 		})
 	assert.NoError(t, err)
 }
@@ -128,13 +128,13 @@ func TestDriver_Create(t *testing.T) {
 	testFlags := map[string]map[string]interface{}{
 		"default": defaultFlags,
 		"ak/sk": {
-			"otc-access-key-id":     testEnv.GetEnv("ACCESS_KEY_ID"),
-			"otc-secret-access-key": testEnv.GetEnv("SECRET_ACCESS_KEY"),
-			"otc-domain-name":       testEnv.GetEnv("DOMAIN_NAME"),
-			"otc-project-name":      testEnv.GetEnv("PROJECT_NAME"),
-			"otc-subnet-name":       defaultFlags["otc-subnet-name"],
-			"otc-vpc-name":          defaultFlags["otc-vpc-name"],
-			"otc-tags":              "machine,test",
+			"otc-access-key":   testEnv.GetEnv("ACCESS_KEY"),
+			"otc-secret-key":   testEnv.GetEnv("SECRET_KEY"),
+			"otc-domain-name":  testEnv.GetEnv("DOMAIN_NAME"),
+			"otc-project-name": testEnv.GetEnv("PROJECT_NAME"),
+			"otc-subnet-name":  defaultFlags["otc-subnet-name"],
+			"otc-vpc-name":     defaultFlags["otc-vpc-name"],
+			"otc-tags":         "machine,test",
 		},
 	}
 

--- a/driver/opentelekomcloud_test.go
+++ b/driver/opentelekomcloud_test.go
@@ -30,7 +30,7 @@ var (
 		"otc-vpc-name":    vpcName,
 		"otc-tags":        "machine,test",
 	}
-	testEnv = openstack.NewEnv("OS_")
+	testEnv = openstack.NewEnv("OTC_")
 )
 
 func newDriverFromFlags(driverFlags map[string]interface{}) (*Driver, error) {


### PR DESCRIPTION
## Summary of pull request

Add missing `OS_` prefixes

Change `otc-access-key-key` to `otc-secret-key`
Change `otc-access-key-id` to `otc-access-key`