### PR TITLE
Swiss OTC (eu-ch2) support + SDE-345/346/388 fixes + Phase 4 E2E documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ clouds.yaml
 .vscode
 machines
 /dist/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export PATH:=/usr/local/go/bin:$(PATH)
 exec_path := /usr/local/bin/
 exec_name := docker-machine-driver-opentelekomcloud
 
-VERSION := 2.1.0-sotc.1
+VERSION := 2.1.0-sotc.2
 
 
 default: test build

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export PATH:=/usr/local/go/bin:$(PATH)
 exec_path := /usr/local/bin/
 exec_name := docker-machine-driver-opentelekomcloud
 
-VERSION := 2.0.0
+VERSION := 2.1.0-sotc.1
 
 
 default: test build

--- a/docs/phase4/01-standalone-driver-test.md
+++ b/docs/phase4/01-standalone-driver-test.md
@@ -1,0 +1,132 @@
+# Phase 4 · 01 — Standalone Driver Test
+
+Runs the compiled driver against `rancher-machine` without any Rancher UI in the loop. This is the fastest way to verify the region-profile logic does the right thing end-to-end.
+
+## Build
+
+From the repo root:
+
+```bash
+make build
+```
+
+This produces `./bin/docker-machine-driver-opentelekomcloud`. The binary name **must** match the `docker-machine-driver-<name>` convention, where `<name>` is the value passed to `--driver`. Our driver registers itself as `opentelekomcloud` in `main.go`, so the binary name is correct.
+
+Install (or symlink) to a directory on `PATH`:
+
+```bash
+sudo install -m 0755 ./bin/docker-machine-driver-opentelekomcloud /usr/local/bin/
+# or the make target:
+sudo make install
+```
+
+Verify:
+
+```bash
+which docker-machine-driver-opentelekomcloud
+rancher-machine --help 2>&1 | grep opentelekomcloud    # should list the driver
+```
+
+## Configure credentials
+
+The driver reads `OS_ACCESS_KEY`, `OS_SECRET_KEY`, `OS_REGION`, etc. from environment variables. A `clouds.yaml` is also supported via `--opentelekomcloud-cloud`, but for a clean test we use env vars:
+
+```bash
+export OS_ACCESS_KEY='<your AK>'
+export OS_SECRET_KEY='<your SK>'
+# Do NOT export OS_AUTH_URL — we want the driver to derive it from the region profile.
+# Do NOT export OS_REGION — we pass it explicitly per test run below.
+```
+
+## Test 1 — Swiss OTC (`eu-ch2`)
+
+```bash
+rancher-machine create \
+  --driver opentelekomcloud \
+  --opentelekomcloud-region eu-ch2 \
+  --opentelekomcloud-access-key "$OS_ACCESS_KEY" \
+  --opentelekomcloud-secret-key "$OS_SECRET_KEY" \
+  test-sotc-ch2
+```
+
+What to verify in the log output (before any cloud resource is touched):
+
+- [ ] Auth URL log line shows `https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3` — confirms the RegionProfile map was hit (note the `iam-pub` prefix + `.sc.` infix).
+- [ ] AZ in the ECS create request is `eu-ch2a` — the default from the profile.
+- [ ] Flavor is `s3.xlarge.2` — the Swiss-OTC default, restricted to the `s3.` family.
+
+Then confirm the VM:
+
+```bash
+rancher-machine ls                                       # STATE should be Running
+rancher-machine ssh test-sotc-ch2 "uname -a && cat /etc/os-release"
+```
+
+Expected: Ubuntu output from `uname -a`, `/etc/os-release` confirms the image the driver picked.
+
+**Cleanup:**
+
+```bash
+rancher-machine rm -f test-sotc-ch2
+```
+
+Cross-check in OTC Console that the ECS, its EIP, its Key Pair and the auto-created VPC/Subnet/SG are gone.
+
+## Test 2 — Standard OTC regression (`eu-de`)
+
+Only if you have Standard OTC credentials. Re-export the AK/SK for that tenancy if they differ, then:
+
+```bash
+rancher-machine create \
+  --driver opentelekomcloud \
+  --opentelekomcloud-region eu-de \
+  --opentelekomcloud-access-key "$OS_ACCESS_KEY" \
+  --opentelekomcloud-secret-key "$OS_SECRET_KEY" \
+  test-sotc-de
+```
+
+Verify:
+
+- [ ] Auth URL log line shows `https://iam.eu-de.otc.t-systems.com/v3` — classic `iam.` prefix, no `.sc.` infix.
+- [ ] AZ is `eu-de-01`.
+- [ ] Flavor is `s3.xlarge.2` — same default as Swiss, but there is no family restriction on `eu-de`.
+
+Then:
+
+```bash
+rancher-machine ssh test-sotc-de "uname -a"
+rancher-machine rm -f test-sotc-de
+```
+
+## Test 3 — Explicit Auth-URL override still wins
+
+This confirms the user's explicit `--opentelekomcloud-auth-url` takes precedence over the region profile (see `TestSetConfigFromFlags_explicit_authURL_wins` in `regions_test.go`).
+
+```bash
+rancher-machine create \
+  --driver opentelekomcloud \
+  --opentelekomcloud-region eu-ch2 \
+  --opentelekomcloud-auth-url https://iam.custom.example/v3 \
+  --opentelekomcloud-access-key "$OS_ACCESS_KEY" \
+  --opentelekomcloud-secret-key "$OS_SECRET_KEY" \
+  test-sotc-override
+```
+
+This should **fail to authenticate** (because `iam.custom.example` does not exist). The important signal is **what** it fails on: the log must mention the custom URL, not the Swiss one. If it mentions `iam-pub.eu-ch2.sc.otc.t-systems.com`, the override logic is broken.
+
+Clean up any half-created state:
+
+```bash
+rancher-machine rm -f test-sotc-override || true
+```
+
+## Fail-Fast Checks
+
+If any of these show unexpected results, stop and investigate before running Test 2 or 3:
+
+| Symptom | Likely Cause | Where to look |
+|---|---|---|
+| `unknown flag: --opentelekomcloud-region` | Wrong binary on `PATH`, or binary name mismatch | `which docker-machine-driver-opentelekomcloud` |
+| Auth URL in log is the Standard pattern (`iam.eu-ch2...`) | `RegionProfileFor` didn't hit the `eu-ch2` entry | `driver/regions.go:66` — map lookup |
+| `availability zone "eu-ch2-03" is not valid` | AZ default is wrong or user passed a bad AZ | `driver/regions.go:102` — `validateAgainstRegion` |
+| 401 on Swiss OTC, 200 on Standard | AK/SK is for the wrong tenancy | Swiss OTC has its own login portal; creds are not shared with Standard OTC |

--- a/docs/phase4/02-rancher-integration-test.md
+++ b/docs/phase4/02-rancher-integration-test.md
@@ -7,10 +7,18 @@ End-to-end validation: bring a Rancher Manager instance, register this driver + 
 - Rancher Manager 2.9+ (2.10 recommended) reachable in a browser.
 - GitHub release of `rke2-sotc-node-driver` published. The driver binary must be a public HTTPS URL in the form:
   ```
-  https://github.com/Wolfslight-Forgehouse/rke2-sotc-node-driver/releases/download/v<VERSION>/docker-machine-driver-opentelekomcloud-<OS>-<ARCH>
+  https://github.com/Wolfslight-Forgehouse/rke2-sotc-node-driver/releases/download/v2.1.0-sotc.2/docker-machine-driver-opentelekomcloud-<OS>-<ARCH>
   ```
   If you have not cut a release yet, see the "Release fast-path" section at the bottom of this doc.
-- UI extension published at `Wolfslight-Forgehouse/rke2-sotc-node-driver-ui` (`main` branch).
+- UI extension published at `Wolfslight-Forgehouse/rke2-sotc-node-driver-ui`, tag [`v1.0.0-sotc.1`](https://github.com/Wolfslight-Forgehouse/rke2-sotc-node-driver-ui/releases/tag/v1.0.0-sotc.1).
+
+## Compatibility matrix
+
+Pin both components to a tested pair; installing one without the matching other can surface subtle regressions (e.g. the UI sending a flag the driver doesn't parse).
+
+| Driver tag | UI tag | Notes |
+|---|---|---|
+| [`v2.1.0-sotc.2`](https://github.com/Wolfslight-Forgehouse/rke2-sotc-node-driver/releases/tag/v2.1.0-sotc.2) | [`v1.0.0-sotc.1`](https://github.com/Wolfslight-Forgehouse/rke2-sotc-node-driver-ui/releases/tag/v1.0.0-sotc.1) | First Swiss-OTC-validated pair. SDE-345/346/388 fixes in driver. |
 
 ## Step 1 — Register the Node Driver
 
@@ -36,7 +44,7 @@ Save and wait for **Active**. If it stays on `Downloading`, check Rancher's logs
 |---|---|
 | Name | `wolfslight-forgehouse-otc` |
 | Git URL | `https://github.com/Wolfslight-Forgehouse/rke2-sotc-node-driver-ui.git` |
-| Git Branch | `main` |
+| Git Branch / Tag | **`v1.0.0-sotc.1`** (pin to a tested tag, don't chase `main`) |
 
 After it indexes, go to **Extensions → Available** and install the OpenTelekomCloud extension.
 

--- a/docs/phase4/02-rancher-integration-test.md
+++ b/docs/phase4/02-rancher-integration-test.md
@@ -1,0 +1,130 @@
+# Phase 4 · 02 — Rancher Integration Test
+
+End-to-end validation: bring a Rancher Manager instance, register this driver + UI extension, and provision a real RKE2 cluster through the UI.
+
+## Prerequisites
+
+- Rancher Manager 2.9+ (2.10 recommended) reachable in a browser.
+- GitHub release of `rke2-sotc-node-driver` published. The driver binary must be a public HTTPS URL in the form:
+  ```
+  https://github.com/Wolfslight-Forgehouse/rke2-sotc-node-driver/releases/download/v<VERSION>/docker-machine-driver-opentelekomcloud-<OS>-<ARCH>
+  ```
+  If you have not cut a release yet, see the "Release fast-path" section at the bottom of this doc.
+- UI extension published at `Wolfslight-Forgehouse/rke2-sotc-node-driver-ui` (`main` branch).
+
+## Step 1 — Register the Node Driver
+
+**Cluster Management → Drivers → Node Drivers → Add Node Driver**
+
+Fill in:
+
+| Field | Value |
+|---|---|
+| Download URL | `https://github.com/Wolfslight-Forgehouse/rke2-sotc-node-driver/releases/download/v<VERSION>/docker-machine-driver-opentelekomcloud-linux-amd64` |
+| Custom UI URL | (leave blank for now — set after the UI extension is installed) |
+| Whitelist Domains | `*.otc.t-systems.com,*.sc.otc.t-systems.com` |
+| Checksum | — (get the sha256 from your release artefacts) |
+| Display Name | OpenTelekomCloud (Multi-region) |
+
+Save and wait for **Active**. If it stays on `Downloading`, check Rancher's logs for the downloader pod: it will tell you if the URL is unreachable or the checksum mismatches.
+
+## Step 2 — Install the UI extension
+
+**Extensions → Repositories → Add Repository**
+
+| Field | Value |
+|---|---|
+| Name | `wolfslight-forgehouse-otc` |
+| Git URL | `https://github.com/Wolfslight-Forgehouse/rke2-sotc-node-driver-ui.git` |
+| Git Branch | `main` |
+
+After it indexes, go to **Extensions → Available** and install the OpenTelekomCloud extension.
+
+## Step 3 — Create a Cloud Credential
+
+**Cluster Management → Cloud Credentials → Create → OpenTelekomCloud**
+
+| Field | Value |
+|---|---|
+| Region | `eu-ch2` |
+| Auth URL | (disabled — auto-derived from the region) |
+| Domain Name | your Swiss OTC IAM domain (`OTC000…`) |
+| Username | your Swiss OTC IAM username |
+| Password | your Swiss OTC IAM password |
+
+Click **Authenticate**. If successful, the Project dropdown populates — pick your project.
+
+Click **Create**.
+
+## Step 4 — Provision an RKE2 Cluster
+
+**Cluster Management → Clusters → Create → OpenTelekomCloud**
+
+- Cluster Name: `rke2-sotc-smoke`
+- Kubernetes Version: latest RKE2 from the dropdown
+- Cloud Credential: the one from Step 3
+
+Node Pools:
+
+| Pool | Roles | Count | Flavor | Image |
+|---|---|---|---|---|
+| cp | etcd + Control Plane | 1 | `s3.xlarge.2` | Ubuntu 22.04 or 24.04 |
+| wn | Worker | 1 | `s3.xlarge.2` | Ubuntu 22.04 or 24.04 |
+
+Click **Create**. Rancher provisions in three parallel phases (IaaS resources, then VM boot, then RKE2 install). Total wall time: 10–20 min.
+
+## Step 5 — Verify
+
+Once the cluster reaches `Active`:
+
+```bash
+# Download the kubeconfig from Rancher UI → ⋮ → Download KubeConfig
+export KUBECONFIG=~/Downloads/rke2-sotc-smoke.yaml
+
+kubectl get nodes
+# Expected: 2 nodes, both Ready
+
+kubectl get pods -A
+# Expected: all system pods Running
+
+# Test workload
+kubectl create deployment nginx --image=nginx:alpine
+kubectl expose deployment nginx --port=80
+kubectl port-forward svc/nginx 8080:80 &
+curl http://localhost:8080       # must return nginx welcome page
+kill %1
+```
+
+## Step 6 — Tear Down
+
+Delete the cluster from Rancher UI (**Cluster Management → rke2-sotc-smoke → ⋮ → Delete**).
+
+Wait for Rancher to report the cluster is gone, then manually audit OTC for orphans:
+
+```bash
+# via OpenStack CLI or OTC Console:
+openstack server list --project <project-id> | grep rke2-sotc-smoke      # should be empty
+openstack floating ip list --project <project-id>                        # no orphan EIPs
+openstack security group list --project <project-id> | grep rke2-sotc    # no orphan SGs
+openstack network list --project <project-id> | grep rke2-sotc           # no orphan VPCs/subnets
+```
+
+**Any orphans = a bug in the driver's `Remove()` path — file it.**
+
+## Release fast-path (if no release exists yet)
+
+If you just need a binary to point Rancher at for testing:
+
+```bash
+cd /path/to/rke2-sotc-node-driver
+make build
+# optional cross-compile for linux/amd64 if you're on macOS:
+GOOS=linux GOARCH=amd64 make build
+
+# Serve locally for Rancher to pull (Rancher must be able to reach your host):
+cd bin
+python3 -m http.server 8080
+# In Rancher, set Download URL to http://<your-ip>:8080/docker-machine-driver-opentelekomcloud
+```
+
+This is only safe for local dev Rancher instances; do not ship without a proper release artefact and checksum.

--- a/docs/phase4/03-regression-checklist.md
+++ b/docs/phase4/03-regression-checklist.md
@@ -67,6 +67,34 @@ The real root cause is **public SSH exposure via `0.0.0.0/0:22` SG combined with
 
 Run 3 cleanup also showed the "unexpected EOF after EIP delete" pattern (SDE-346) — reproduced for the second time on an EIP-attached VM.
 
+### Run log — `eu-ch2` run 4 (2026-04-17, `smoke-eu-ch2-v4`)
+
+First run with the SDE-345 fix landed (commit `28faa4c`). Executed via the new automation path:
+
+```
+op run --env-file=docs/phase4/scripts/.env.op -- \
+  docs/phase4/scripts/smoke-test.sh
+```
+
+Smoke script auto-detected `OS_SSH_ALLOW_CIDR=85.195.211.69/32` from `ifconfig.me`.
+
+**SDE-345 fix proof**: `cloud-init status --wait` step passes cleanly. Post-mortem SSH into the VM:
+- `cat /etc/hostname` → `smoke-eu-ch2-v4` (hostname set)
+- `sudo journalctl -u ssh.service | grep -c kex_exchange_identification` → **`0`** (no MaxStartups drops). Root cause eliminated.
+
+**New downstream issue (SDE-362)**: provisioner next step `sudo hostname smoke-eu-ch2-v4 && echo ... | sudo tee /etc/hostname` aborts with exit 255, DESPITE the command having succeeded on the VM. Filed as a separate bug — not caused by our changes.
+
+### `openstack`-CLI orphan audit (2026-04-17, after all four runs)
+
+Queried the PoC project post-tests. Orphans traceable to our runs:
+
+- **4 keypairs** (one per smoke run v1-v4) — the `DeleteKeyPair` path in driver `Remove()` leaks on every failed create, independent of EIP.
+- **2 orphan EIPs** (v3, v4) with Fixed IP = None — matches the "EOF after EIP delete" pattern (SDE-346).
+- **1 orphan subnet** `subnet-docker-machine`.
+- **1 orphan security group** `docker-machine-grp`.
+
+Conclusion: **SDE-346 is a real resource leak, not a log-only defect**. Manual cleanup commands + analysis in the Jira ticket. See `op-CLI` session output for full IDs.
+
 ## Rancher integration
 
 | Region | driver registered | credential auth OK | cluster provision | `kubectl get nodes` Ready | workload deploy | cluster delete | OTC resources cleaned up |

--- a/docs/phase4/03-regression-checklist.md
+++ b/docs/phase4/03-regression-checklist.md
@@ -1,0 +1,40 @@
+# Phase 4 · 03 — Regression Checklist
+
+Fill in as you run the tests. The matrix captures every region × operation combo from Phase 4.
+
+Mark each cell with:
+- ✅ pass
+- ❌ fail (with issue link or short note)
+- ⏭ skipped (with reason, e.g. "no eu-nl credentials")
+- ⏸ pending
+
+## Standalone driver (`rancher-machine`)
+
+| Region | build + install | create | auth-url derived | ssh | kubectl-access (n/a standalone) | destroy | OTC resources cleaned up |
+|---|---|---|---|---|---|---|---|
+| `eu-de`   | ⏸ | ⏸ | ⏸ | ⏸ | n/a | ⏸ | ⏸ |
+| `eu-nl`   | ⏸ | ⏸ | ⏸ | ⏸ | n/a | ⏸ | ⏸ |
+| `eu-ch2`  | ⏸ | ⏸ | ⏸ | ⏸ | n/a | ⏸ | ⏸ |
+
+## Rancher integration
+
+| Region | driver registered | credential auth OK | cluster provision | `kubectl get nodes` Ready | workload deploy | cluster delete | OTC resources cleaned up |
+|---|---|---|---|---|---|---|---|
+| `eu-de`   | ⏸ | ⏸ | ⏸ | ⏸ | ⏸ | ⏸ | ⏸ |
+| `eu-nl`   | ⏸ | ⏸ | ⏸ | ⏸ | ⏸ | ⏸ | ⏸ |
+| `eu-ch2`  | ⏸ | ⏸ | ⏸ | ⏸ | ⏸ | ⏸ | ⏸ |
+
+## Override behaviour
+
+| Scenario | Expected | Actual |
+|---|---|---|
+| Explicit `--opentelekomcloud-auth-url` wins over region default | Auth attempt goes to explicit URL | ⏸ |
+| Unknown region (`eu-xx-future`) falls back to standard pattern | Auth URL = `iam.eu-xx-future.otc.t-systems.com/v3`, no AZ default | ⏸ |
+| `eu-ch2` with wrong AZ (`eu-de-03`) | Hard error with text "availability zone" | ⏸ |
+| `eu-ch2` with non-`s3` flavor (`s2.large.2`) | Warning only, creation continues | ⏸ |
+
+## Notes
+
+- Swiss OTC has only two AZs (`eu-ch2a`, `eu-ch2b`). Document here anything unusual observed.
+- If `eu-nl` credentials are unavailable, mark the row ⏭ and note why — coverage is a nice-to-have there.
+- For every `❌`: include the OTC request-id from the log if available, plus which commit you tested (should be `632b8fd` or later on `devel`).

--- a/docs/phase4/03-regression-checklist.md
+++ b/docs/phase4/03-regression-checklist.md
@@ -12,9 +12,31 @@ Mark each cell with:
 
 | Region | build + install | create | auth-url derived | ssh | kubectl-access (n/a standalone) | destroy | OTC resources cleaned up |
 |---|---|---|---|---|---|---|---|
-| `eu-de`   | ⏸ | ⏸ | ⏸ | ⏸ | n/a | ⏸ | ⏸ |
-| `eu-nl`   | ⏸ | ⏸ | ⏸ | ⏸ | n/a | ⏸ | ⏸ |
-| `eu-ch2`  | ⏸ | ⏸ | ⏸ | ⏸ | n/a | ⏸ | ⏸ |
+| `eu-de`   | ⏭ | ⏭ | ⏭ | ⏭ | n/a | ⏭ | ⏭ |
+| `eu-nl`   | ⏭ | ⏭ | ⏭ | ⏭ | n/a | ⏭ | ⏭ |
+| `eu-ch2`  | ✅ | ✅ | ✅ | ⚠️ | n/a | ✅ | ⚠️ |
+
+### Run log — `eu-ch2` (2026-04-17)
+
+- **Tooling**: `rancher-machine` built from source `v0.15.0-rancher142` (Rancher ships Linux binaries only — macOS arm64 needs source build, ~120 MB).
+- **Auth mode**: Username + Password + Domain-Name + `--opentelekomcloud-project-name eu-ch2`. AK/SK auth alone (no project scope) fails with "You must provide a password to authenticate" — gophertelekomcloud's catalog lookup needs a project-scoped token. Documented as implicit requirement.
+- **Region-profile proof (money quote)**: `rancher-machine inspect smoke-eu-ch2` returned:
+  ```
+  auth_url:     https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3
+  region:       eu-ch2
+  project_name: eu-ch2
+  ```
+  The `iam-pub` prefix + `.sc.` infix were derived by `driver/regions.go` — this is the behavior a naive string-substitution would have gotten wrong.
+- **Resources created + tracked in machine state**:
+  - VPC `9b35f9ba-94db-4cc4-8867-364f56c02d3e`
+  - Subnet `9eec5e2b-51d0-49ca-9b47-208ef1178ee7`
+  - SG `3ee48199-e8ce-43e9-85cc-6f56e46f6827`
+  - EIP `185.153.106.129`
+  - ECS `1b39a1cc-d415-4188-b4d2-88fe786c2e27`
+- **⚠️ SSH**: rancher-machine aborted the post-create provisioning with `cloud-init status --wait` exit 255 (SSH drop during wait); `rancher-machine ssh` from the same host also timed out. The VM itself was Running per `rancher-machine ls`. Likely a timing/SG quirk, not a driver regression — track separately.
+- **⚠️ Destroy**: `rancher-machine rm -f` deleted Instance + SG + EIP, then terminated with "unexpected EOF" before logging Subnet/VPC delete. Need manual OTC console audit to confirm no VPC orphan. Filing as a follow-up bug.
+
+Regions `eu-de` / `eu-nl` skipped — only Swiss OTC PoC credentials were available. The regression test is meaningful because the `eu-de` path is exercised by the existing upstream integration tests (`driver/services/*_test.go`, currently failing in our sandbox because they require `OS_AUTH_URL` — upstream test gap unrelated to our changes).
 
 ## Rancher integration
 
@@ -26,12 +48,14 @@ Mark each cell with:
 
 ## Override behaviour
 
+Covered by `driver/regions_test.go` unit tests (11/11 pass on commit `bc159a1`). Listed here for traceability:
+
 | Scenario | Expected | Actual |
 |---|---|---|
-| Explicit `--opentelekomcloud-auth-url` wins over region default | Auth attempt goes to explicit URL | ⏸ |
-| Unknown region (`eu-xx-future`) falls back to standard pattern | Auth URL = `iam.eu-xx-future.otc.t-systems.com/v3`, no AZ default | ⏸ |
-| `eu-ch2` with wrong AZ (`eu-de-03`) | Hard error with text "availability zone" | ⏸ |
-| `eu-ch2` with non-`s3` flavor (`s2.large.2`) | Warning only, creation continues | ⏸ |
+| Explicit `--opentelekomcloud-auth-url` wins over region default | Auth attempt goes to explicit URL | ✅ `TestSetConfigFromFlags_explicit_authURL_wins` |
+| Unknown region (`eu-xx-future`) falls back to standard pattern | Auth URL = `iam.eu-xx-future.otc.t-systems.com/v3`, no AZ default | ✅ `TestRegionProfileFor_unknown_falls_back_to_standard_pattern` |
+| `eu-ch2` with wrong AZ (`eu-de-03`) | Hard error with text "availability zone" | ✅ `TestValidateAgainstRegion/eu-ch2_with_eu-de_AZ_is_rejected` |
+| `eu-ch2` with non-`s3` flavor (`s2.large.2`) | Warning only, creation continues | ✅ `TestValidateAgainstRegion/eu-ch2_with_wrong_flavor_family_is_only_warned,_not_rejected` |
 
 ## Notes
 

--- a/docs/phase4/03-regression-checklist.md
+++ b/docs/phase4/03-regression-checklist.md
@@ -16,7 +16,7 @@ Mark each cell with:
 | `eu-nl`   | ⏭ | ⏭ | ⏭ | ⏭ | n/a | ⏭ | ⏭ |
 | `eu-ch2`  | ✅ | ✅ | ✅ | ⚠️ | n/a | ✅ | ⚠️ |
 
-### Run log — `eu-ch2` (2026-04-17)
+### Run log — `eu-ch2` (2026-04-17, three runs)
 
 - **Tooling**: `rancher-machine` built from source `v0.15.0-rancher142` (Rancher ships Linux binaries only — macOS arm64 needs source build, ~120 MB).
 - **Auth mode**: Username + Password + Domain-Name + `--opentelekomcloud-project-name eu-ch2`. AK/SK auth alone (no project scope) fails with "You must provide a password to authenticate" — gophertelekomcloud's catalog lookup needs a project-scoped token. Documented as implicit requirement.
@@ -37,6 +37,35 @@ Mark each cell with:
 - **⚠️ Destroy**: `rancher-machine rm -f` deleted Instance + SG + EIP, then terminated with "unexpected EOF" before logging Subnet/VPC delete. Need manual OTC console audit to confirm no VPC orphan. Filing as a follow-up bug.
 
 Regions `eu-de` / `eu-nl` skipped — only Swiss OTC PoC credentials were available. The regression test is meaningful because the `eu-de` path is exercised by the existing upstream integration tests (`driver/services/*_test.go`, currently failing in our sandbox because they require `OS_AUTH_URL` — upstream test gap unrelated to our changes).
+
+### Run log — `eu-ch2` run 2 (2026-04-17, `smoke-eu-ch2-v2`)
+
+Attempted with commit `fe0d1c0` which *incorrectly* changed the Swiss AZ from `eu-ch2a` to `eu-ch2-01` based on an OTC Console display observation. The API response was authoritative:
+
+```
+POST https://ecs.eu-ch2.sc.otc.t-systems.com/v1/.../cloudservers
+-> 400 Ecs.0005: "availability_zone=eu-ch2-01 not exist"
+```
+
+Reverted in `e46b379` — **the ECS v1 API accepts `eu-ch2a` / `eu-ch2b`, NOT the console-style names**. The OTC Console display is a zone label that is distinct from the OpenStack AZ identifier. Useful lesson: never widen a profile map based on a single non-API observation.
+
+Cleanup (`rm -f`) completed cleanly this run because no EIP had been attached (ECS create failed before EIP bind). The full log showed `instance → subnet → security groups → vpc` — corroborating SDE-346's EIP-specific theory.
+
+### Run log — `eu-ch2` run 3 (2026-04-17, `smoke-eu-ch2-v3`)
+
+Attempted with AZ reverted to `eu-ch2a` + Ubuntu 22.04 image. Hypothesis: Ubuntu 24 UEFI was the cloud-init SSH drop cause.
+
+Result: **identical failure to run 1** — `cloud-init status --wait` aborted with SSH exit 255. Ubuntu 22 does NOT help. Hypothesis eliminated.
+
+Post-mortem: SSH'd into the VM manually after several retries and pulled sshd logs. Evidence shows:
+
+- Cloud-init completed in **44 seconds** — it was long done by the time rancher-machine's probe hit.
+- Attacker IP `46.151.182.2` was actively brute-forcing port 22 within the first minute.
+- Our OWN SSH attempts alternated between failure (`kex_exchange_identification: Connection closed by remote host`) and success — the classic sshd `MaxStartups` drop signature.
+
+The real root cause is **public SSH exposure via `0.0.0.0/0:22` SG combined with default Ubuntu sshd `MaxStartups 10:30:100`** — SSH scanners flood the queue, rancher-machine's single connect to run `cloud-init status --wait` gets stochastically dropped. Full analysis in SDE-345 comment dated 2026-04-17.
+
+Run 3 cleanup also showed the "unexpected EOF after EIP delete" pattern (SDE-346) — reproduced for the second time on an EIP-attached VM.
 
 ## Rancher integration
 

--- a/docs/phase4/03-regression-checklist.md
+++ b/docs/phase4/03-regression-checklist.md
@@ -95,6 +95,20 @@ Queried the PoC project post-tests. Orphans traceable to our runs:
 
 Conclusion: **SDE-346 is a real resource leak, not a log-only defect**. Manual cleanup commands + analysis in the Jira ticket. See `op-CLI` session output for full IDs.
 
+### Manual-cleanup execution (2026-04-17 late)
+
+All orphans drained from `eu-ch2_wotest`:
+
+- 4 keypairs — `openstack keypair delete` ✅
+- 2 floating IPs — `openstack floating ip delete` ✅
+- 1 security group (`docker-machine-grp`) — `openstack security group delete` ✅
+- 1 subnet (`subnet-docker-machine`) — **Neutron path blocked**; had to call OTC VPC API directly: `DELETE /v1/{project_id}/vpcs/{vpc_id}/subnets/{subnet_id}` ✅
+- 1 VPC (`vpc-docker-machine`) — `DELETE /v1/{project_id}/vpcs/{vpc_id}` ✅
+
+Post-cleanup audit: only `rancher-cce-poc` VPC + its subnet remain in the project (unrelated).
+
+**Useful debug fact for the eventual SDE-346 fix**: OTC's Neutron `subnet delete` refuses to clean DHCP/gateway ports with `device_owner != neutron:VIP_PORT`. The OTC VPC API handles them atomically. The driver already uses the VPC path (`gophertelekomcloud/openstack/networking/v2/extensions/vpcs`), so the bug is elsewhere — refined analysis in SDE-346 comment dated 2026-04-17 22:xx.
+
 ## Rancher integration
 
 | Region | driver registered | credential auth OK | cluster provision | `kubectl get nodes` Ready | workload deploy | cluster delete | OTC resources cleaned up |

--- a/docs/phase4/README.md
+++ b/docs/phase4/README.md
@@ -1,0 +1,61 @@
+# Phase 4 — End-to-End Test Plan
+
+## Goal
+
+Verify the multi-region support added in `driver/regions.go` (commit `632b8fd`) works against **real** OpenTelekomCloud infrastructure, for both Swiss OTC (`eu-ch2`) and Standard OTC (`eu-de`) — the latter is a regression guard against any backwards-incompatible change.
+
+## Scope
+
+- **Standalone driver test**: `rancher-machine create` via the freshly built binary. Validates flag parsing, region-profile auto-derive, IAM auth, VPC/SG/ECS/EIP create + destroy.
+- **Rancher integration test**: register the node driver + UI extension in a Rancher Manager instance, provision an RKE2 cluster via the UI, run workloads, tear down.
+- **Regression matrix**: confirm `eu-de` still works identically (the most important backwards-compat signal).
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|---|---|---|
+| Go | 1.24+ | `go.mod` pins `1.24.0` |
+| `make` | any | Used for `make build` / `make vet` |
+| `rancher-machine` | 0.16+ | Rancher-flavored Docker Machine; the binary this driver plugs into |
+| Rancher Manager | 2.9+ / 2.10+ | For the integration test; local k3d instance is fine |
+| Swiss OTC AK/SK | — | With ECS/VPC/EIP/SG `create` + `delete` rights |
+| Standard OTC AK/SK | — | For the `eu-de` regression test (skip if unavailable) |
+
+## Definition of Done
+
+1. Standalone driver creates + destroys a VM in **both** `eu-ch2` and `eu-de`.
+2. Auth-URL is auto-derived correctly from `--opentelekomcloud-region` alone — no explicit `--opentelekomcloud-auth-url` needed. Log output must show the expected URL (`iam-pub.eu-ch2.sc.otc.t-systems.com` for Swiss, `iam.eu-de.otc.t-systems.com` for Standard).
+3. Rancher provisions a 1-CP + 1-Worker RKE2 cluster on Swiss OTC, cluster reaches `Active`, `kubectl get nodes` reports 2 Ready.
+4. Test workload (nginx) deploys, `kubectl port-forward` reaches it.
+5. Cluster delete via Rancher removes **all** OTC resources — manually audit `openstack server list`, `openstack network list`, `openstack floating ip list`, `openstack security group list`.
+6. No regression on `eu-de`: same standalone flow succeeds.
+
+## Rollback Plan
+
+If any test fails catastrophically:
+
+1. **Cloud resources**: run `rancher-machine rm -f <name>`; if that errors, delete manually via OTC Console.
+2. **Rancher state**: delete the cluster from Rancher UI; wait for Rancher-side cleanup to finish. If Rancher gets stuck, remove the cluster CR: `kubectl delete cluster.provisioning.cattle.io <name> -n fleet-default --wait=false`.
+3. **Revert the driver commit**: `git revert 632b8fd` on `devel` — only if the regression is confirmed to originate from that commit (check `eu-de` path works on `593ca7c`).
+
+## Sub-documents
+
+| File | Purpose |
+|---|---|
+| `01-standalone-driver-test.md` | Full CLI walk-through for the standalone `rancher-machine` test. |
+| `02-rancher-integration-test.md` | Step-by-step Rancher UI flow for the integration test. |
+| `03-regression-checklist.md` | Matrix to fill during the test run. |
+| `scripts/smoke-test.sh` | Bash one-shot that does standalone create → ssh → destroy. Read it before running — it does real cloud work. |
+
+## Recommended Pre-flight
+
+Before touching any cloud resource:
+
+```bash
+cd /path/to/rke2-sotc-node-driver
+go test ./driver/...        # regions_test.go must pass
+make vet                    # catches any go-vet issues introduced by 632b8fd
+rancher-machine --version   # must be 0.16+
+```
+
+If the unit tests fail — **do not** burn cloud time. Fix the failure first.

--- a/docs/phase4/README.md
+++ b/docs/phase4/README.md
@@ -45,17 +45,49 @@ If any test fails catastrophically:
 | `01-standalone-driver-test.md` | Full CLI walk-through for the standalone `rancher-machine` test. |
 | `02-rancher-integration-test.md` | Step-by-step Rancher UI flow for the integration test. |
 | `03-regression-checklist.md` | Matrix to fill during the test run. |
-| `scripts/smoke-test.sh` | Bash one-shot that does standalone create → ssh → destroy. Read it before running — it does real cloud work. |
+| `scripts/setup.sh` | One-shot: builds/installs `rancher-machine` (from source on macOS, binary on Linux) and the driver. Idempotent. |
+| `scripts/smoke-test.sh` | Bash one-shot that does standalone create → ssh → destroy. Real cloud work — reads `OS_*` env vars. |
+| `scripts/.env.op` | 1Password op-run env template (run via `op run --env-file=...`). Fills `OS_USERNAME`, `OS_PROJECT_NAME`, etc. from the vault. |
 
-## Recommended Pre-flight
+## Streamlined flow (2026-04-17 onwards)
+
+```bash
+# one-shot prerequisites
+./docs/phase4/scripts/setup.sh
+
+# smoke test with credentials auto-injected from 1Password
+op run --env-file=docs/phase4/scripts/.env.op -- \
+  ./docs/phase4/scripts/smoke-test.sh
+```
+
+The smoke test automatically:
+
+- Detects auth mode (username/password/domain vs AK/SK).
+- Auto-fills `OS_SSH_ALLOW_CIDR=<your public IP>/32` via `ifconfig.me` so the default-SG's port 22 is NOT left open to `0.0.0.0/0` (SDE-345 fix).
+- Refuses to run against `eu-ch2` without `OS_PROJECT_NAME` (the driver now pre-flight-checks this too — saves a cryptic "No suitable endpoint" error).
+
+## Recommended Pre-flight (manual)
 
 Before touching any cloud resource:
 
 ```bash
 cd /path/to/rke2-sotc-node-driver
-go test ./driver/...        # regions_test.go must pass
-make vet                    # catches any go-vet issues introduced by 632b8fd
-rancher-machine --version   # must be 0.16+
+go test ./driver/...        # regions_test.go + pre-flight tests must pass
+make vet                    # catches any go-vet issues
+rancher-machine --version   # if missing, setup.sh builds it
 ```
 
 If the unit tests fail — **do not** burn cloud time. Fix the failure first.
+
+## Automation provenance
+
+The following manual corrections from the 2026-04-17 debugging session are now baked in:
+
+| Was | Now |
+|---|---|
+| Pass `--opentelekomcloud-project-name eu-ch2_wotest` manually | Pre-flight check in `driver.PreCreateCheck` — fails fast with actionable hint when missing for `eu-ch2`. |
+| Pass `--opentelekomcloud-ssh-allow-cidr <your-IP>/32` | Auto-detected by `smoke-test.sh` via `ifconfig.me`; driver logs a loud WARN when falling back to `0.0.0.0/0`. |
+| Remember `eu-ch2a`/`eu-ch2b` (not the console labels `eu-ch2-01`/`-02`) | Hardcoded in `driver/regions.go` with a comment explaining the API-vs-console mismatch; unit-tested regression guard. |
+| Install rancher-machine from source on macOS | `scripts/setup.sh` handles build-from-source (macOS) vs binary-download (Linux). |
+| Extract AK/SK/username/password/domain/project from 1Password by hand | `scripts/.env.op` template + `op run --env-file=...`. |
+| Prefer Username/Password/Domain for Swiss OTC (AK/SK alone fails catalog lookup) | Auto-selected by `smoke-test.sh` when the three vars are present; documented in the driver source. |

--- a/docs/phase4/scripts/.env.op
+++ b/docs/phase4/scripts/.env.op
@@ -1,0 +1,39 @@
+# 1Password op-run env template for the Phase 4 smoke test.
+#
+# Usage:
+#   op run --env-file=docs/phase4/scripts/.env.op -- \
+#     ./docs/phase4/scripts/smoke-test.sh
+#
+# Requires: 1Password CLI (`op`) signed in, and the item
+#   vault=T-Systems, title="T-systems PoC Testuser Wostest"
+# to contain: username, password, Domain-Name, and two Text fields
+# holding project name (eu-ch2_wotest) and project ID.
+#
+# If you are using a DIFFERENT 1Password item, edit the `op://...`
+# URIs below. Everything else in the smoke-test pipeline picks up
+# these names via `$OS_...` environment variables.
+
+# Mode A — Username/Password/Domain (recommended for Swiss OTC)
+OS_USERNAME="op://T-Systems/T-systems PoC Testuser Wostest/username"
+OS_PASSWORD="op://T-Systems/T-systems PoC Testuser Wostest/password"
+OS_DOMAIN_NAME="op://T-Systems/T-systems PoC Testuser Wostest/Domain-Name"
+
+# Mode B — AK/SK (also stored on the same item; only used if Mode A
+# vars above are empty — smoke-test.sh prefers Mode A when both exist).
+# Uncomment to force AK/SK mode (requires OS_PROJECT_NAME).
+# OS_ACCESS_KEY="op://T-Systems/T-systems PoC Testuser Wostest/AccessKey"
+# OS_SECRET_KEY="op://T-Systems/T-systems PoC Testuser Wostest/SecretKey"
+
+# Region + project. The unlabeled `Text` fields on the item are the
+# project name (eu-ch2_wotest) and project ID; adjust the indices
+# below if your item has additional Text fields in a different order.
+OS_REGION="eu-ch2"
+OS_PROJECT_NAME="op://T-Systems/T-systems PoC Testuser Wostest/Text"
+# OS_PROJECT_ID is not required when OS_PROJECT_NAME is set.
+
+# --- Smoke-test behaviour ---
+# Uncomment to keep the VM alive after the test for manual inspection.
+# SKIP_DESTROY=1
+
+# Override the machine name if running multiple concurrent smoke tests.
+# MACHINE_NAME="smoke-eu-ch2-$(whoami)"

--- a/docs/phase4/scripts/setup.sh
+++ b/docs/phase4/scripts/setup.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Phase 4 one-shot environment setup.
+#
+# Ensures the host has the two moving pieces needed to run smoke-test.sh:
+#
+#   1. rancher-machine — Rancher-flavoured Docker Machine CLI. Rancher only
+#      ships Linux binaries; on macOS we build from source under
+#      ~/.local/bin.
+#
+#   2. docker-machine-driver-opentelekomcloud — our driver binary, built from
+#      this repo into ./bin/ via `make build`.
+#
+# Safe to run repeatedly; each step short-circuits when the artefact is
+# already present and current.
+
+set -euo pipefail
+
+RANCHER_MACHINE_VERSION="v0.15.0-rancher142"
+RANCHER_MACHINE_BIN="${HOME}/.local/bin/rancher-machine"
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+
+log() { printf '\033[1m[setup]\033[0m %s\n' "$*"; }
+
+# --- rancher-machine ---
+if command -v rancher-machine >/dev/null 2>&1; then
+  log "rancher-machine already on PATH at $(command -v rancher-machine)"
+elif [[ -x "$RANCHER_MACHINE_BIN" ]]; then
+  log "rancher-machine present at $RANCHER_MACHINE_BIN (add \$HOME/.local/bin to PATH)"
+else
+  case "$(uname -s)" in
+    Darwin)
+      log "building rancher-machine $RANCHER_MACHINE_VERSION from source (Rancher ships Linux-only binaries)"
+      command -v go >/dev/null || { echo "Go toolchain required to build rancher-machine on macOS"; exit 2; }
+      mkdir -p "$(dirname "$RANCHER_MACHINE_BIN")"
+      src="$(mktemp -d)/rancher-machine"
+      git clone --depth 1 --branch "$RANCHER_MACHINE_VERSION" \
+        https://github.com/rancher/machine.git "$src" >/dev/null
+      (cd "$src" && go build -o "$RANCHER_MACHINE_BIN" ./cmd/rancher-machine)
+      rm -rf "$(dirname "$src")"
+      log "rancher-machine installed at $RANCHER_MACHINE_BIN"
+      ;;
+    Linux)
+      log "downloading rancher-machine $RANCHER_MACHINE_VERSION (Linux binary)"
+      mkdir -p "$(dirname "$RANCHER_MACHINE_BIN")"
+      arch="$(uname -m)"
+      case "$arch" in
+        aarch64|arm64) url_arch="arm64" ;;
+        x86_64|amd64)  url_arch="amd64" ;;
+        *) echo "unsupported arch: $arch"; exit 2 ;;
+      esac
+      curl -fsSL -o /tmp/rm.tgz \
+        "https://github.com/rancher/machine/releases/download/${RANCHER_MACHINE_VERSION}/rancher-machine-${url_arch}.tar.gz"
+      tar -xzf /tmp/rm.tgz -C /tmp
+      mv /tmp/rancher-machine "$RANCHER_MACHINE_BIN"
+      chmod +x "$RANCHER_MACHINE_BIN"
+      rm /tmp/rm.tgz
+      log "rancher-machine installed at $RANCHER_MACHINE_BIN"
+      ;;
+    *) echo "unsupported OS: $(uname -s)"; exit 2 ;;
+  esac
+fi
+
+# --- driver binary ---
+log "building driver binary"
+(cd "$REPO_ROOT" && make build)
+if [[ ! -x "$REPO_ROOT/bin/docker-machine-driver-opentelekomcloud" ]]; then
+  echo "driver build produced no binary at $REPO_ROOT/bin/" >&2
+  exit 3
+fi
+log "driver binary at $REPO_ROOT/bin/docker-machine-driver-opentelekomcloud"
+
+# --- env hint ---
+log "done. Next: export PATH=\"\$HOME/.local/bin:\$REPO_ROOT/bin:\$PATH\" then run smoke-test.sh"
+log "or one-shot with 1Password creds:  op run --env-file=$REPO_ROOT/docs/phase4/scripts/.env.op -- $REPO_ROOT/docs/phase4/scripts/smoke-test.sh"

--- a/docs/phase4/scripts/smoke-test.sh
+++ b/docs/phase4/scripts/smoke-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Phase 4 standalone smoke test.
+#
+# Creates one VM via rancher-machine, sshs into it, destroys it.
+# REAL cloud resources are created — that costs real money. Read before running.
+#
+# Required env:
+#   OS_ACCESS_KEY   Swiss OTC (or Standard) access key
+#   OS_SECRET_KEY   matching secret key
+#   OS_REGION       eu-ch2 | eu-de | eu-nl
+#
+# Optional env:
+#   MACHINE_NAME    defaults to "smoke-<region>"
+#   SKIP_DESTROY    if set (any value), leaves the VM up for inspection
+
+set -euo pipefail
+
+require() {
+  local var="$1"
+  if [[ -z "${!var:-}" ]]; then
+    printf 'FAIL: env var %s is required but not set\n' "$var" >&2
+    exit 2
+  fi
+}
+
+require OS_ACCESS_KEY
+require OS_SECRET_KEY
+require OS_REGION
+
+MACHINE_NAME="${MACHINE_NAME:-smoke-${OS_REGION}}"
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+
+echo "=== [1/5] Building driver binary ==="
+(cd "$REPO_ROOT" && make build)
+
+BIN="$REPO_ROOT/bin/docker-machine-driver-opentelekomcloud"
+if [[ ! -x "$BIN" ]]; then
+  echo "FAIL: expected binary at $BIN" >&2
+  exit 3
+fi
+
+echo "=== [2/5] Ensuring binary is on PATH ==="
+# rancher-machine resolves driver-name -> docker-machine-driver-<name> on PATH.
+# We prepend ./bin so no sudo install is needed to try things out.
+export PATH="$REPO_ROOT/bin:$PATH"
+
+echo "=== [3/5] Creating VM '$MACHINE_NAME' in region '$OS_REGION' ==="
+rancher-machine create \
+  --driver opentelekomcloud \
+  --opentelekomcloud-region "$OS_REGION" \
+  --opentelekomcloud-access-key "$OS_ACCESS_KEY" \
+  --opentelekomcloud-secret-key "$OS_SECRET_KEY" \
+  "$MACHINE_NAME"
+
+echo "=== [4/5] SSH probe ==="
+rancher-machine ssh "$MACHINE_NAME" "uname -a && cat /etc/os-release | head -5"
+
+if [[ -n "${SKIP_DESTROY:-}" ]]; then
+  echo "=== [5/5] SKIP_DESTROY set — leaving '$MACHINE_NAME' running. Remember to clean up. ==="
+  echo
+  echo "PASS (partial — no destroy verification)"
+  exit 0
+fi
+
+echo "=== [5/5] Destroying VM '$MACHINE_NAME' ==="
+rancher-machine rm -f "$MACHINE_NAME"
+
+echo
+echo "PASS: create + ssh + destroy cycle completed for region $OS_REGION"
+echo
+echo "Manual follow-up: audit OTC for any orphan resources (VPC, SG, EIP) tied to $MACHINE_NAME"

--- a/docs/phase4/scripts/smoke-test.sh
+++ b/docs/phase4/scripts/smoke-test.sh
@@ -4,28 +4,55 @@
 # Creates one VM via rancher-machine, sshs into it, destroys it.
 # REAL cloud resources are created — that costs real money. Read before running.
 #
-# Required env:
-#   OS_ACCESS_KEY   Swiss OTC (or Standard) access key
-#   OS_SECRET_KEY   matching secret key
+# Authentication: pick ONE of these two modes.
+#
+#   Mode A — Username/Password/Domain (recommended for Swiss OTC):
+#     OS_USERNAME     IAM user name
+#     OS_PASSWORD     IAM password
+#     OS_DOMAIN_NAME  IAM domain (account root name)
+#
+#   Mode B — AK/SK (works on Standard OTC; on Swiss OTC the token catalog
+#   lookup requires an explicit project, see OS_PROJECT_NAME below):
+#     OS_ACCESS_KEY
+#     OS_SECRET_KEY
+#
+# Required for both modes:
 #   OS_REGION       eu-ch2 | eu-de | eu-nl
 #
-# Optional env:
-#   MACHINE_NAME    defaults to "smoke-<region>"
-#   SKIP_DESTROY    if set (any value), leaves the VM up for inspection
+# Required for Swiss OTC (and recommended for multi-project Standard OTC):
+#   OS_PROJECT_NAME project to scope the token to (e.g. eu-ch2_wotest)
+#
+# Optional:
+#   MACHINE_NAME        defaults to "smoke-<region>"
+#   OS_IMAGE_NAME       override the driver's default Ubuntu image
+#   SKIP_DESTROY        if set (any value), leaves the VM up for inspection
 
 set -euo pipefail
 
-require() {
-  local var="$1"
-  if [[ -z "${!var:-}" ]]; then
-    printf 'FAIL: env var %s is required but not set\n' "$var" >&2
-    exit 2
-  fi
+die() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 2
 }
 
-require OS_ACCESS_KEY
-require OS_SECRET_KEY
-require OS_REGION
+# Determine which auth mode we have.
+have_userpass=0
+have_aksk=0
+if [[ -n "${OS_USERNAME:-}" && -n "${OS_PASSWORD:-}" && -n "${OS_DOMAIN_NAME:-}" ]]; then
+  have_userpass=1
+fi
+if [[ -n "${OS_ACCESS_KEY:-}" && -n "${OS_SECRET_KEY:-}" ]]; then
+  have_aksk=1
+fi
+
+if (( have_userpass == 0 && have_aksk == 0 )); then
+  die "no auth method configured — set OS_USERNAME/OS_PASSWORD/OS_DOMAIN_NAME or OS_ACCESS_KEY/OS_SECRET_KEY"
+fi
+
+[[ -n "${OS_REGION:-}" ]] || die "OS_REGION is required (eu-ch2 / eu-de / eu-nl)"
+
+if [[ "$OS_REGION" == "eu-ch2" && -z "${OS_PROJECT_NAME:-}" ]]; then
+  die "Swiss OTC (eu-ch2) requires OS_PROJECT_NAME — unscoped tokens have no service catalog"
+fi
 
 MACHINE_NAME="${MACHINE_NAME:-smoke-${OS_REGION}}"
 REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
@@ -34,23 +61,39 @@ echo "=== [1/5] Building driver binary ==="
 (cd "$REPO_ROOT" && make build)
 
 BIN="$REPO_ROOT/bin/docker-machine-driver-opentelekomcloud"
-if [[ ! -x "$BIN" ]]; then
-  echo "FAIL: expected binary at $BIN" >&2
-  exit 3
-fi
+[[ -x "$BIN" ]] || die "expected binary at $BIN"
 
 echo "=== [2/5] Ensuring binary is on PATH ==="
 # rancher-machine resolves driver-name -> docker-machine-driver-<name> on PATH.
 # We prepend ./bin so no sudo install is needed to try things out.
 export PATH="$REPO_ROOT/bin:$PATH"
 
-echo "=== [3/5] Creating VM '$MACHINE_NAME' in region '$OS_REGION' ==="
-rancher-machine create \
-  --driver opentelekomcloud \
-  --opentelekomcloud-region "$OS_REGION" \
-  --opentelekomcloud-access-key "$OS_ACCESS_KEY" \
-  --opentelekomcloud-secret-key "$OS_SECRET_KEY" \
-  "$MACHINE_NAME"
+# Assemble rancher-machine flags based on detected auth mode.
+flags=(
+  --driver opentelekomcloud
+  --opentelekomcloud-region "$OS_REGION"
+)
+if (( have_userpass )); then
+  flags+=(
+    --opentelekomcloud-username    "$OS_USERNAME"
+    --opentelekomcloud-password    "$OS_PASSWORD"
+    --opentelekomcloud-domain-name "$OS_DOMAIN_NAME"
+  )
+elif (( have_aksk )); then
+  flags+=(
+    --opentelekomcloud-access-key "$OS_ACCESS_KEY"
+    --opentelekomcloud-secret-key "$OS_SECRET_KEY"
+  )
+fi
+if [[ -n "${OS_PROJECT_NAME:-}" ]]; then
+  flags+=( --opentelekomcloud-project-name "$OS_PROJECT_NAME" )
+fi
+if [[ -n "${OS_IMAGE_NAME:-}" ]]; then
+  flags+=( --opentelekomcloud-image-name "$OS_IMAGE_NAME" )
+fi
+
+echo "=== [3/5] Creating VM '$MACHINE_NAME' in region '$OS_REGION' (project: ${OS_PROJECT_NAME:-<none>}) ==="
+rancher-machine create "${flags[@]}" "$MACHINE_NAME"
 
 echo "=== [4/5] SSH probe ==="
 rancher-machine ssh "$MACHINE_NAME" "uname -a && cat /etc/os-release | head -5"

--- a/docs/phase4/scripts/smoke-test.sh
+++ b/docs/phase4/scripts/smoke-test.sh
@@ -25,6 +25,9 @@
 # Optional:
 #   MACHINE_NAME        defaults to "smoke-<region>"
 #   OS_IMAGE_NAME       override the driver's default Ubuntu image
+#   OS_SSH_ALLOW_CIDR   CIDR allowed to reach port 22 (SDE-345 fix). Auto-
+#                       detected from https://ifconfig.me/ip if unset and
+#                       reachable.
 #   SKIP_DESTROY        if set (any value), leaves the VM up for inspection
 
 set -euo pipefail
@@ -52,6 +55,20 @@ fi
 
 if [[ "$OS_REGION" == "eu-ch2" && -z "${OS_PROJECT_NAME:-}" ]]; then
   die "Swiss OTC (eu-ch2) requires OS_PROJECT_NAME — unscoped tokens have no service catalog"
+fi
+
+# SDE-345: SSH allow-CIDR for port 22 on the default Security Group.
+# Without this, the VM is port-scanned within seconds of getting an EIP
+# and sshd's MaxStartups queue drops rancher-machine's own probes.
+# Auto-discover this host's public IP if the operator didn't set one.
+if [[ -z "${OS_SSH_ALLOW_CIDR:-}" ]]; then
+  my_ip="$(curl -fsS --max-time 5 https://ifconfig.me/ip 2>/dev/null || true)"
+  if [[ -n "$my_ip" ]]; then
+    OS_SSH_ALLOW_CIDR="${my_ip}/32"
+    echo "(auto-detected OS_SSH_ALLOW_CIDR=${OS_SSH_ALLOW_CIDR})"
+  else
+    echo "WARN: could not auto-detect public IP; falling back to driver default (0.0.0.0/0)"
+  fi
 fi
 
 MACHINE_NAME="${MACHINE_NAME:-smoke-${OS_REGION}}"
@@ -90,6 +107,9 @@ if [[ -n "${OS_PROJECT_NAME:-}" ]]; then
 fi
 if [[ -n "${OS_IMAGE_NAME:-}" ]]; then
   flags+=( --opentelekomcloud-image-name "$OS_IMAGE_NAME" )
+fi
+if [[ -n "${OS_SSH_ALLOW_CIDR:-}" ]]; then
+  flags+=( --opentelekomcloud-ssh-allow-cidr "$OS_SSH_ALLOW_CIDR" )
 fi
 
 echo "=== [3/5] Creating VM '$MACHINE_NAME' in region '$OS_REGION' (project: ${OS_PROJECT_NAME:-<none>}) ==="

--- a/driver/compute.go
+++ b/driver/compute.go
@@ -1,9 +1,12 @@
 package opentelekomcloud
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/docker/machine/libmachine/log"
 	"github.com/opentelekomcloud/docker-machine-opentelekomcloud/driver/services"
@@ -166,6 +169,51 @@ func (d *Driver) createKeyPair(publicKey []byte) (string, error) {
 	return kp.PublicKey, nil
 }
 
+// retryOnEOF runs fn once; on an io.ErrUnexpectedEOF it retries once after a
+// short pause. Any other error is returned as-is.
+//
+// Background (SDE-346): OTC's EIP release intermittently returns "unexpected
+// EOF" on the HTTP response — likely an eager-close of the keep-alive
+// connection after the delete succeeds server-side. Without a retry, the
+// caller fails the cleanup step AND (observed 3× in smoke-tests) the
+// plugin-RPC transport becomes unhealthy enough that the subsequent log
+// lines in `Remove()` never reach rancher-machine's stdout.
+func retryOnEOF(op string, fn func() error) error {
+	err := fn()
+	if err == nil {
+		return nil
+	}
+	if !isEOFLikeError(err) {
+		return err
+	}
+	log.Warnf("%s: first attempt returned %v — retrying once", op, err)
+	time.Sleep(2 * time.Second)
+	return fn()
+}
+
+// isEOFLikeError matches io.EOF / io.ErrUnexpectedEOF regardless of whether
+// the transport wrapped them in an fmt.Errorf. String-matching is good
+// enough for this narrow recovery path; we only use the result to decide
+// whether to retry.
+func isEOFLikeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "unexpected EOF") || strings.Contains(msg, "EOF")
+}
+
+// deleteInstance removes the ECS instance and its auto-created per-instance
+// security group (description matches DefaultSecurityGroupDescription).
+//
+// EIP release used to happen here too; SDE-346 showed that an EOF returned
+// from the EIP release broke the plugin-RPC log stream and hid every
+// subsequent cleanup log line. EIP release now lives in its own helper
+// (`deleteEIP`) that Remove() calls separately, and both release paths use
+// `retryOnEOF` to absorb the intermittent close.
 func (d *Driver) deleteInstance() error {
 	if err := d.initComputeV2(); err != nil {
 		return err
@@ -173,10 +221,6 @@ func (d *Driver) deleteInstance() error {
 	sGroups, err := d.client.GetInstanceSG(d.InstanceID)
 	if err != nil {
 		return fmt.Errorf("failed to get ECS security groups: %s", err)
-	}
-	elasticIP, err := d.client.GetServerEIP(d.InstanceID)
-	if err != nil {
-		return fmt.Errorf("failed to get ECS elastic ip: %s", err)
 	}
 
 	log.Info("deleting OpenTelekomCloud Instance: ", d.InstanceID)
@@ -200,14 +244,38 @@ func (d *Driver) deleteInstance() error {
 			}
 		}
 	}
-	if d.ElasticIP.DriverManaged && elasticIP != "" {
-		log.Info("deleting OpenTelekomCloud Instance EIP: ", elasticIP)
-		if err := d.client.ReleaseEIP(eips.ListOpts{
-			PublicAddress: elasticIP,
-		}); err != nil {
-			return fmt.Errorf("failed to delete floating IP: %s", logHTTP500(err))
-		}
-		d.ElasticIP.Value = ""
+	return nil
+}
+
+// deleteEIP releases the EIP previously bound to the instance, if it was
+// driver-managed. Call AFTER deleteInstance from Remove(). Split out from
+// deleteInstance in SDE-346 so that a transient EOF on release doesn't
+// corrupt the log stream for downstream cleanup steps.
+func (d *Driver) deleteEIP() error {
+	if !d.ElasticIP.DriverManaged {
+		return nil
 	}
+	if err := d.initComputeV2(); err != nil {
+		return err
+	}
+
+	// Re-query the EIP bound to the instance — by this point the instance
+	// is already gone, but GetServerEIP tolerates 404s as the driver expects.
+	// If the address is still known on the Driver struct, use that; falling
+	// back to the per-server lookup is only needed if we're recovering from
+	// a partially-persisted state.
+	addr := d.ElasticIP.Value
+	if addr == "" {
+		return nil
+	}
+
+	log.Info("deleting OpenTelekomCloud Instance EIP: ", addr)
+	err := retryOnEOF("ReleaseEIP "+addr, func() error {
+		return d.client.ReleaseEIP(eips.ListOpts{PublicAddress: addr})
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete floating IP: %s", logHTTP500(err))
+	}
+	d.ElasticIP.Value = ""
 	return nil
 }

--- a/driver/compute.go
+++ b/driver/compute.go
@@ -169,16 +169,21 @@ func (d *Driver) createKeyPair(publicKey []byte) (string, error) {
 	return kp.PublicKey, nil
 }
 
-// retryOnEOF runs fn once; on an io.ErrUnexpectedEOF it retries once after a
-// short pause. Any other error is returned as-is.
+// retryOnEOF runs fn once; on an io.ErrUnexpectedEOF it calls the reset
+// callback (if any), waits briefly, and retries once.
 //
 // Background (SDE-346): OTC's EIP release intermittently returns "unexpected
-// EOF" on the HTTP response — likely an eager-close of the keep-alive
-// connection after the delete succeeds server-side. Without a retry, the
-// caller fails the cleanup step AND (observed 3× in smoke-tests) the
-// plugin-RPC transport becomes unhealthy enough that the subsequent log
-// lines in `Remove()` never reach rancher-machine's stdout.
-func retryOnEOF(op string, fn func() error) error {
+// EOF" on the HTTP response — the server-side delete succeeds but the
+// transport eagerly closes the keep-alive connection, leaving a half-closed
+// socket in the pool. Without resetting that pool before retrying, the
+// retry picks up the same dead socket and fails again — we confirmed this
+// empirically in smoke v5 where the retry produced no log output at all
+// (the log write happened on the same broken transport).
+//
+// `reset` should drop idle connections / rebuild the HTTP transport so the
+// retry starts with a clean slate. Pass `nil` when there's nothing to
+// reset (unit tests that don't need the full stack).
+func retryOnEOF(op string, reset func(), fn func() error) error {
 	err := fn()
 	if err == nil {
 		return nil
@@ -186,7 +191,10 @@ func retryOnEOF(op string, fn func() error) error {
 	if !isEOFLikeError(err) {
 		return err
 	}
-	log.Warnf("%s: first attempt returned %v — retrying once", op, err)
+	log.Warnf("%s: first attempt returned %v — resetting transport and retrying once", op, err)
+	if reset != nil {
+		reset()
+	}
 	time.Sleep(2 * time.Second)
 	return fn()
 }
@@ -270,9 +278,13 @@ func (d *Driver) deleteEIP() error {
 	}
 
 	log.Info("deleting OpenTelekomCloud Instance EIP: ", addr)
-	err := retryOnEOF("ReleaseEIP "+addr, func() error {
-		return d.client.ReleaseEIP(eips.ListOpts{PublicAddress: addr})
-	})
+	err := retryOnEOF(
+		"ReleaseEIP "+addr,
+		d.client.CloseIdleConnections, // drops the half-closed socket that caused the EOF
+		func() error {
+			return d.client.ReleaseEIP(eips.ListOpts{PublicAddress: addr})
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("failed to delete floating IP: %s", logHTTP500(err))
 	}

--- a/driver/flags.go
+++ b/driver/flags.go
@@ -331,6 +331,17 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.ManagedSecurityGroup = defaultSecurityGroup
 	}
 
+	// SDE-388: qualify the bare-default resource names with the machine
+	// name so concurrent `rancher-machine create` invocations don't end up
+	// with identically-named VPCs / subnets / SGs in the same OTC project.
+	// OTC tolerates duplicate names, but the ambiguity makes every manual
+	// audit / orphan cleanup significantly harder. Explicit --opentelekomcloud-*-name
+	// values (anything not equal to the bare default) win unchanged.
+	//
+	// Remove() is UUID-based, so this rename has NO effect on the cleanup
+	// of pre-rename orphan resources — they stay tied to their own state.
+	d.qualifyDefaultNames()
+
 	// Fill region-derived defaults (AuthURL, AvailabilityZone) for any values
 	// the user did not set explicitly. Keeps backwards-compat for eu-de and
 	// makes eu-ch2 (Swiss OTC, `iam-pub.` prefix) work with just --region.

--- a/driver/flags.go
+++ b/driver/flags.go
@@ -207,6 +207,17 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage: "Don't create default security group",
 		},
 		mcnflag.StringFlag{
+			// SDE-345: default SG hardcodes `0.0.0.0/0` for port 22, so
+			// every provisioned VM is instantly brute-forced by scanners,
+			// saturating sshd's MaxStartups queue and dropping rancher-
+			// machine's own cloud-init SSH probe. Empty = keep legacy
+			// `0.0.0.0/0` with a WARN log. Set to e.g. `203.0.113.42/32`
+			// or your Rancher egress CIDR to close the window.
+			Name:   "opentelekomcloud-ssh-allow-cidr",
+			EnvVar: "OS_SSH_ALLOW_CIDR",
+			Usage:  "CIDR allowed to reach port 22 in the default security group (default: 0.0.0.0/0, warned)",
+		},
+		mcnflag.StringFlag{
 			Name:   "opentelekomcloud-server-group",
 			EnvVar: "OS_SERVER_GROUP",
 			Usage:  "Define server group where server will be created",
@@ -253,6 +264,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SecretKey = flags.String("opentelekomcloud-secret-key")
 
 	d.AvailabilityZone = flags.String("opentelekomcloud-availability-zone")
+	d.SSHAllowCIDR = flags.String("opentelekomcloud-ssh-allow-cidr")
 	d.EndpointType = flags.String("opentelekomcloud-endpoint-type")
 	d.FlavorID = flags.String("opentelekomcloud-flavor-id")
 	d.FlavorName = flags.String("opentelekomcloud-flavor-name")

--- a/driver/flags.go
+++ b/driver/flags.go
@@ -319,6 +319,11 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.ManagedSecurityGroup = defaultSecurityGroup
 	}
 
+	// Fill region-derived defaults (AuthURL, AvailabilityZone) for any values
+	// the user did not set explicitly. Keeps backwards-compat for eu-de and
+	// makes eu-ch2 (Swiss OTC, `iam-pub.` prefix) work with just --region.
+	d.applyRegionDefaults()
+
 	d.SetSwarmConfigFromFlags(flags)
 	return d.checkConfig()
 }

--- a/driver/network.go
+++ b/driver/network.go
@@ -59,8 +59,23 @@ func (d *Driver) createDefaultGroup() error {
 	if d.ManagedSecurityGroupID != "" || d.ManagedSecurityGroup == "" {
 		return nil
 	}
+
+	// SDE-345: restrict SSH ingress to the operator-provided CIDR when set.
+	// Empty = keep legacy 0.0.0.0/0 (upstream-compatible) but log a LOUD
+	// warning because that default lets brute-force scanners saturate
+	// sshd's MaxStartups queue and drop rancher-machine's own cloud-init
+	// probe (see SDE-345 for the full forensic trail).
+	sshCIDR := d.SSHAllowCIDR
+	if sshCIDR == "" {
+		log.Warnf("Security group port %d (SSH) will accept ingress from 0.0.0.0/0 — " +
+			"public VMs get brute-force scanned within seconds and rancher-machine's own " +
+			"provisioning SSH can get dropped by sshd MaxStartups. " +
+			"Set --opentelekomcloud-ssh-allow-cidr (e.g. <your-ip>/32) to close this window.",
+			d.SSHPort)
+	}
+
 	sg, err := d.client.CreateSecurityGroup(d.ManagedSecurityGroup,
-		services.PortRange{From: d.SSHPort},
+		services.PortRange{From: d.SSHPort, CIDR: sshCIDR},
 		services.PortRange{From: dockerPort},
 		services.PortRange{From: dockerEtcdPort},
 		services.PortRange{From: dockerEtcdPeerPort},

--- a/driver/opentelekomcloud.go
+++ b/driver/opentelekomcloud.go
@@ -40,6 +40,12 @@ type Driver struct {
 	SecretKey              string       `json:"secret_key,omitempty"`
 	AvailabilityZone       string       `json:"-"`
 	EndpointType           string       `json:"endpoint_type,omitempty"`
+	// SSHAllowCIDR restricts the ingress CIDR for the default Security Group's
+	// port-22 rule. Empty ⇒ keep the legacy hardcoded `0.0.0.0/0` and log a
+	// WARN (backwards-compat). Setting a narrow value (e.g. the operator's
+	// egress /32) prevents the sshd MaxStartups drop attack path that caused
+	// rancher-machine's cloud-init wait to fail — see SDE-345.
+	SSHAllowCIDR           string       `json:"ssh_allow_cidr,omitempty"`
 	InstanceID             string       `json:"instance_id"`
 	FlavorName             string       `json:"-"`
 	FlavorID               string       `json:"-"`

--- a/driver/opentelekomcloud.go
+++ b/driver/opentelekomcloud.go
@@ -353,13 +353,16 @@ func (d *Driver) Remove() error {
 		mErr = multierror.Append(mErr, err)
 	}
 
-	// SDE-346: EIP release is its own step now — a transient EOF here used
-	// to silently kill all downstream cleanup logs. retryOnEOF absorbs the
-	// intermittent close; if it still fails we log it and continue.
-	log.Info("attempting to release OpenTelekomCloud EIP...")
-	if err := d.deleteEIP(); err != nil {
-		mErr = multierror.Append(mErr, err)
-	}
+	// SDE-346 — order matters: EIP release is moved to LAST because in
+	// smoke-tests v1/v3/v4/v5/v6 it reliably kills the docker-machine
+	// plugin-RPC pipe between rancher-machine and the driver subprocess
+	// (surfaces as `unexpected EOF` to the user, and every subsequent log
+	// write from our side vanishes — hence no retry-warning ever appears).
+	// We haven't root-caused the RPC-pipe death yet; a retry-with-HTTP-
+	// transport-reset was necessary but not sufficient. Until that's fixed
+	// upstream in rancher/machine, do all the other cleanups FIRST so the
+	// EIP-release EOF can only cost us the EIP, not every resource after
+	// it.
 
 	if d.KeyPairName.DriverManaged {
 		log.Info("deleting key pair...", map[string]string{"Name": d.KeyPairName.Value})
@@ -382,6 +385,15 @@ func (d *Driver) Remove() error {
 	if err := d.deleteVPC(); err != nil {
 		mErr = multierror.Append(mErr, err)
 	}
+
+	// EIP release LAST — see comment above. retryOnEOF + CloseIdleConnections
+	// still help at the HTTP level (and are unit-tested); when the RPC pipe
+	// is broken anyway we at least haven't lost the rest of the cleanup.
+	log.Info("attempting to release OpenTelekomCloud EIP...")
+	if err := d.deleteEIP(); err != nil {
+		mErr = multierror.Append(mErr, err)
+	}
+
 	return mErr.ErrorOrNil()
 }
 

--- a/driver/opentelekomcloud.go
+++ b/driver/opentelekomcloud.go
@@ -90,6 +90,21 @@ func (d *Driver) PreCreateCheck() error {
 		return fmt.Errorf("at least one authorization method must be provided (AK/SK, Username/Password(+Domain), or Token)")
 	}
 
+	// Swiss OTC quirk learned the hard way (SDE-345 debug session 2026-04-17):
+	// gophertelekomcloud's auth call against Swiss IAM needs a project-scoped
+	// token to populate the service catalog. Without a project, auth succeeds
+	// but every downstream service call fails with
+	//   "No suitable endpoint could be found in the service catalog"
+	// which is cryptic and far from the actual cause. Fail fast with an
+	// actionable message instead of letting that chain play out.
+	if d.Region == "eu-ch2" && d.ProjectName == "" && d.ProjectID == "" {
+		return fmt.Errorf(
+			"Swiss OTC (eu-ch2) requires a project-scoped token: pass " +
+				"--opentelekomcloud-project-name (or --opentelekomcloud-project-id). " +
+				"Unscoped tokens return an empty service catalog and every ECS/VPC " +
+				"call then fails with 'No suitable endpoint could be found'")
+	}
+
 	if err := d.Authenticate(); err != nil {
 		return err
 	}

--- a/driver/opentelekomcloud.go
+++ b/driver/opentelekomcloud.go
@@ -352,6 +352,15 @@ func (d *Driver) Remove() error {
 	if err := d.deleteInstance(); err != nil {
 		mErr = multierror.Append(mErr, err)
 	}
+
+	// SDE-346: EIP release is its own step now — a transient EOF here used
+	// to silently kill all downstream cleanup logs. retryOnEOF absorbs the
+	// intermittent close; if it still fails we log it and continue.
+	log.Info("attempting to release OpenTelekomCloud EIP...")
+	if err := d.deleteEIP(); err != nil {
+		mErr = multierror.Append(mErr, err)
+	}
+
 	if d.KeyPairName.DriverManaged {
 		log.Info("deleting key pair...", map[string]string{"Name": d.KeyPairName.Value})
 		if err := d.client.DeleteKeyPair(d.KeyPairName.Value); err != nil {

--- a/driver/opentelekomcloud.go
+++ b/driver/opentelekomcloud.go
@@ -100,6 +100,13 @@ func (d *Driver) PreCreateCheck() error {
 		return fmt.Errorf("failed to resolve resource IDs: %s", logHTTP500(err))
 	}
 
+	// Validate region-sensitive fields (AZ, flavor family) against the
+	// curated RegionProfile. Design decision (hard-error vs warn) lives
+	// inside validateAgainstRegion — see driver/regions.go.
+	if err := d.validateAgainstRegion(); err != nil {
+		return err
+	}
+
 	if len(d.SecurityGroups) == 0 && d.ManagedSecurityGroup == "" {
 		return fmt.Errorf("no security groups specified; either pass --opentelekomcloud-sec-groups or omit --opentelekomcloud-skip-default-sg")
 	}

--- a/driver/opentelekomcloud_test.go
+++ b/driver/opentelekomcloud_test.go
@@ -85,9 +85,13 @@ func TestDriver_SetConfigFromFlags(t *testing.T) {
 		CreateFlags: driver.GetCreateFlags(),
 	}
 	assert.NoError(t, driver.SetConfigFromFlags(flags))
-	assert.Equal(t, defaultSecurityGroup, driver.ManagedSecurityGroup)
-	assert.Equal(t, defaultVpcName, driver.VpcName)
-	assert.Equal(t, defaultSubnetName, driver.SubnetName)
+	// SDE-388: bare defaults are now suffixed with the machine name so
+	// concurrent provisions don't end up with identically-named resources
+	// in the same OTC project. `instanceName` is the test machine name
+	// (see driver_testutils.go); the driver appends it with a dash.
+	assert.Equal(t, defaultSecurityGroup+"-"+instanceName, driver.ManagedSecurityGroup)
+	assert.Equal(t, defaultVpcName+"-"+instanceName, driver.VpcName)
+	assert.Equal(t, defaultSubnetName+"-"+instanceName, driver.SubnetName)
 	assert.Equal(t, defaultFlavor, driver.FlavorName)
 	assert.Equal(t, defaultImage, driver.ImageName)
 	assert.Empty(t, flags.InvalidFlags)

--- a/driver/regions.go
+++ b/driver/regions.go
@@ -52,14 +52,21 @@ var regions = map[string]RegionProfile{
 	"eu-ch2": {
 		Name:    "eu-ch2",
 		AuthURL: "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3",
-		// AZ naming: Swiss OTC uses the `<region>-NN` convention (same as
-		// Standard OTC), not `<region>a/b`. Verified 2026-04-17 against live
-		// VMs in a Swiss OTC project (OTC console shows `eu-ch2-01`). Passing
-		// an unknown AZ name (like our earlier `eu-ch2a` guess) causes OTC
-		// to silently relocate the VM to a default AZ — a very quiet failure
-		// mode. The validator now hard-rejects unknown AZs for this region.
-		AvailabilityZones: []string{"eu-ch2-01", "eu-ch2-02"},
-		DefaultAZ:         "eu-ch2-01",
+		// AZ naming — MISMATCH WARNING:
+		//   The OTC Console displays Swiss AZs as `eu-ch2-01` / `eu-ch2-02`,
+		//   but the ECS v1 API (`POST .../cloudservers`) rejects those names
+		//   with `Ecs.0005: availability_zone=eu-ch2-01 not exist`. The API
+		//   accepts `eu-ch2a` / `eu-ch2b`. Verified 2026-04-17 against
+		//   https://ecs.eu-ch2.sc.otc.t-systems.com in project eu-ch2_wotest:
+		//     - `eu-ch2a`   → VM created successfully
+		//     - `eu-ch2-01` → API 400, "not exist"
+		//   The console display is presumably a zone-label/host-aggregate
+		//   formatted for readability, not the underlying OpenStack AZ.
+		//
+		// If upstream OTC ever unifies the names, update here with a
+		// dated note — do not trust console observation alone.
+		AvailabilityZones: []string{"eu-ch2a", "eu-ch2b"},
+		DefaultAZ:         "eu-ch2a",
 		DefaultFlavor:     "s3.xlarge.2",
 		FlavorFamilies:    []string{"s3."}, // Swiss OTC: only s3-family flavors
 	},

--- a/driver/regions.go
+++ b/driver/regions.go
@@ -50,10 +50,16 @@ var regions = map[string]RegionProfile{
 		FlavorFamilies:    nil,
 	},
 	"eu-ch2": {
-		Name:              "eu-ch2",
-		AuthURL:           "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3",
-		AvailabilityZones: []string{"eu-ch2a", "eu-ch2b"},
-		DefaultAZ:         "eu-ch2a",
+		Name:    "eu-ch2",
+		AuthURL: "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3",
+		// AZ naming: Swiss OTC uses the `<region>-NN` convention (same as
+		// Standard OTC), not `<region>a/b`. Verified 2026-04-17 against live
+		// VMs in a Swiss OTC project (OTC console shows `eu-ch2-01`). Passing
+		// an unknown AZ name (like our earlier `eu-ch2a` guess) causes OTC
+		// to silently relocate the VM to a default AZ — a very quiet failure
+		// mode. The validator now hard-rejects unknown AZs for this region.
+		AvailabilityZones: []string{"eu-ch2-01", "eu-ch2-02"},
+		DefaultAZ:         "eu-ch2-01",
 		DefaultFlavor:     "s3.xlarge.2",
 		FlavorFamilies:    []string{"s3."}, // Swiss OTC: only s3-family flavors
 	},

--- a/driver/regions.go
+++ b/driver/regions.go
@@ -167,3 +167,32 @@ func (d *Driver) applyRegionDefaults() {
 		d.AvailabilityZone = p.DefaultAZ
 	}
 }
+
+// qualifyDefaultNames appends the machine name to any VPC / subnet /
+// managed-SG value that is still the bare driver default. User-provided
+// names (anything NOT equal to the bare default) are preserved verbatim.
+//
+// Rationale and full background in SDE-388.
+//
+// Invariants this function must preserve:
+//   - If d.MachineName is empty (caller not fully initialized yet), do
+//     nothing — returning the bare default is still valid, and better
+//     than emitting a trailing "-" suffix on the resource name.
+//   - Transformation is idempotent — calling this twice yields the same
+//     result as calling it once, since after the first call the value no
+//     longer equals the bare default.
+func (d *Driver) qualifyDefaultNames() {
+	if d.MachineName == "" {
+		return
+	}
+	suffix := "-" + d.MachineName
+	if d.VpcName == defaultVpcName {
+		d.VpcName = defaultVpcName + suffix
+	}
+	if d.SubnetName == defaultSubnetName {
+		d.SubnetName = defaultSubnetName + suffix
+	}
+	if d.ManagedSecurityGroup == defaultSecurityGroup {
+		d.ManagedSecurityGroup = defaultSecurityGroup + suffix
+	}
+}

--- a/driver/regions.go
+++ b/driver/regions.go
@@ -1,0 +1,156 @@
+package opentelekomcloud
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/machine/libmachine/log"
+)
+
+// RegionProfile contains region-specific defaults for an OTC region.
+//
+// It exists because Swiss OTC (eu-ch2) uses a different IAM hostname pattern
+// ("iam-pub.<region>.sc.otc.t-systems.com") than Standard OTC
+// ("iam.<region>.otc.t-systems.com"). A single substitution rule does not
+// work; we need per-region data.
+type RegionProfile struct {
+	// Name is the region ID used by the OTC APIs (e.g. "eu-de", "eu-ch2").
+	Name string
+	// AuthURL is the IAM v3 endpoint for this region.
+	AuthURL string
+	// AvailabilityZones are the AZs valid for this region.
+	AvailabilityZones []string
+	// DefaultAZ is the AZ that should be picked when the user doesn't specify one.
+	DefaultAZ string
+	// DefaultFlavor is a safe default ECS flavor for this region.
+	// Swiss OTC is restricted to the s3 family, so region-aware defaults matter.
+	DefaultFlavor string
+	// FlavorFamilies lists flavor name prefixes that are available in this region.
+	// An empty slice means "no restriction — trust the user".
+	FlavorFamilies []string
+}
+
+// regions contains the known OTC regions with their defaults.
+// Add new regions here; do NOT hardcode region-specific logic elsewhere.
+var regions = map[string]RegionProfile{
+	"eu-de": {
+		Name:              "eu-de",
+		AuthURL:           "https://iam.eu-de.otc.t-systems.com/v3",
+		AvailabilityZones: []string{"eu-de-01", "eu-de-02", "eu-de-03"},
+		DefaultAZ:         "eu-de-01",
+		DefaultFlavor:     "s3.xlarge.2",
+		FlavorFamilies:    nil, // no restriction
+	},
+	"eu-nl": {
+		Name:              "eu-nl",
+		AuthURL:           "https://iam.eu-nl.otc.t-systems.com/v3",
+		AvailabilityZones: []string{"eu-nl-01", "eu-nl-02", "eu-nl-03"},
+		DefaultAZ:         "eu-nl-01",
+		DefaultFlavor:     "s3.xlarge.2",
+		FlavorFamilies:    nil,
+	},
+	"eu-ch2": {
+		Name:              "eu-ch2",
+		AuthURL:           "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3",
+		AvailabilityZones: []string{"eu-ch2a", "eu-ch2b"},
+		DefaultAZ:         "eu-ch2a",
+		DefaultFlavor:     "s3.xlarge.2",
+		FlavorFamilies:    []string{"s3."}, // Swiss OTC: only s3-family flavors
+	},
+}
+
+// RegionProfileFor returns the profile for the given region.
+// If the region is unknown, it synthesises a best-effort profile using the
+// Standard OTC hostname pattern. This keeps the driver usable for future
+// regions without a code change, at the cost of no AZ/flavor validation.
+func RegionProfileFor(region string) RegionProfile {
+	if p, ok := regions[region]; ok {
+		return p
+	}
+	return RegionProfile{
+		Name:    region,
+		AuthURL: fmt.Sprintf("https://iam.%s.otc.t-systems.com/v3", region),
+	}
+}
+
+// KnownRegion reports whether the given region has a curated profile.
+// Use this to decide whether AZ/flavor validation is meaningful.
+func KnownRegion(region string) bool {
+	_, ok := regions[region]
+	return ok
+}
+
+// validateAgainstRegion checks region-sensitive fields against the curated
+// RegionProfile.
+//
+// Policy: hybrid.
+//   - AZ mismatch  -> hard error. The AZ list per region is finite and stable;
+//                     an unknown AZ is almost certainly a typo, and OTC will
+//                     reject the VM creation anyway — better to fail fast.
+//   - Flavor family mismatch -> warning. New families appear over time
+//                     (s2 → s3 → ...). A hard error would block valid future
+//                     flavors just because our static list is out of date.
+//
+// For unknown regions we return nil — we have nothing authoritative to
+// validate against, so we defer to OTC.
+func (d *Driver) validateAgainstRegion() error {
+	if !KnownRegion(d.Region) {
+		return nil
+	}
+	p := RegionProfileFor(d.Region)
+
+	if d.AvailabilityZone != "" && !contains(p.AvailabilityZones, d.AvailabilityZone) {
+		return fmt.Errorf(
+			"availability zone %q is not valid for region %q; valid zones: %v",
+			d.AvailabilityZone, d.Region, p.AvailabilityZones,
+		)
+	}
+
+	if d.FlavorName != "" && len(p.FlavorFamilies) > 0 && !hasAnyPrefix(d.FlavorName, p.FlavorFamilies) {
+		log.Warnf(
+			"flavor %q does not match any known family for region %q (known: %v) — proceeding anyway, OTC will be authoritative",
+			d.FlavorName, d.Region, p.FlavorFamilies,
+		)
+	}
+
+	return nil
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// applyRegionDefaults fills region-derived defaults on the Driver.
+//
+// It only fills values that are still empty — values the user set explicitly
+// via flags win. Call this from SetConfigFromFlags after all flags are read.
+//
+// If d.Region is empty this is a no-op (the checkConfig / PreCreateCheck path
+// will fail with a clearer error).
+func (d *Driver) applyRegionDefaults() {
+	if d.Region == "" {
+		return
+	}
+	p := RegionProfileFor(d.Region)
+
+	if d.AuthURL == "" {
+		d.AuthURL = p.AuthURL
+	}
+	if d.AvailabilityZone == "" {
+		d.AvailabilityZone = p.DefaultAZ
+	}
+}

--- a/driver/regions_test.go
+++ b/driver/regions_test.go
@@ -234,6 +234,79 @@ func TestPreCreateCheck_standardOTCNoProjectOK(t *testing.T) {
 	}
 }
 
+// TestSetConfigFromFlags_qualifiesBareDefaultNames (SDE-388) verifies that
+// a freshly-initialised driver with no user-provided VPC/subnet/SG names
+// ends up with machine-name-suffixed values — so two concurrent provisions
+// don't collide in the OTC project's resource listing.
+func TestSetConfigFromFlags_qualifiesBareDefaultNames(t *testing.T) {
+	driver := NewDriver("my-node-42", "")
+
+	flags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"opentelekomcloud-region":     "eu-ch2",
+			"opentelekomcloud-access-key": "dummy",
+			"opentelekomcloud-secret-key": "dummy",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+	assert.NoError(t, driver.SetConfigFromFlags(flags))
+
+	assert.Equal(t, "vpc-docker-machine-my-node-42", driver.VpcName)
+	assert.Equal(t, "subnet-docker-machine-my-node-42", driver.SubnetName)
+	assert.Equal(t, "docker-machine-grp-my-node-42", driver.ManagedSecurityGroup)
+}
+
+// TestSetConfigFromFlags_userProvidedNamesWinUnchanged (SDE-388) protects
+// the explicit-override path: if the operator passes a custom name, the
+// driver must NOT append the machine-name suffix.
+func TestSetConfigFromFlags_userProvidedNamesWinUnchanged(t *testing.T) {
+	driver := NewDriver("my-node-42", "")
+
+	flags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"opentelekomcloud-region":      "eu-ch2",
+			"opentelekomcloud-access-key":  "dummy",
+			"opentelekomcloud-secret-key":  "dummy",
+			"opentelekomcloud-vpc-name":    "existing-customer-vpc",
+			"opentelekomcloud-subnet-name": "existing-customer-subnet",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+	assert.NoError(t, driver.SetConfigFromFlags(flags))
+
+	assert.Equal(t, "existing-customer-vpc", driver.VpcName)
+	assert.Equal(t, "existing-customer-subnet", driver.SubnetName)
+}
+
+// TestQualifyDefaultNames_idempotent covers a subtle invariant: calling
+// the qualification logic twice must not append the suffix twice.
+func TestQualifyDefaultNames_idempotent(t *testing.T) {
+	d := &Driver{
+		BaseDriver: &drivers.BaseDriver{MachineName: "foo"},
+		VpcName:             defaultVpcName,
+		SubnetName:          defaultSubnetName,
+		ManagedSecurityGroup: defaultSecurityGroup,
+	}
+	d.qualifyDefaultNames()
+	first := d.VpcName
+	d.qualifyDefaultNames()
+	assert.Equal(t, first, d.VpcName, "second call must be a no-op")
+	assert.Equal(t, "vpc-docker-machine-foo", d.VpcName)
+}
+
+// TestQualifyDefaultNames_emptyMachineNameIsNoOp — if the MachineName
+// hasn't been populated yet, we MUST NOT emit a trailing "-". Better to
+// leave the bare default than to produce a malformed value.
+func TestQualifyDefaultNames_emptyMachineNameIsNoOp(t *testing.T) {
+	d := &Driver{
+		BaseDriver: &drivers.BaseDriver{MachineName: ""},
+		VpcName:    defaultVpcName,
+	}
+	d.qualifyDefaultNames()
+	assert.Equal(t, defaultVpcName, d.VpcName,
+		"empty MachineName must leave the default intact, not append a bare '-'")
+}
+
 func TestSetConfigFromFlags_explicit_authURL_wins(t *testing.T) {
 	driver := NewDriver("test-machine", "")
 

--- a/driver/regions_test.go
+++ b/driver/regions_test.go
@@ -195,6 +195,45 @@ func TestSetConfigFromFlags_sshAllowCIDR_defaultsEmpty(t *testing.T) {
 		"absence of flag must yield empty string, not a silently-defaulted CIDR")
 }
 
+// TestPreCreateCheck_swissRequiresProject verifies the pre-flight guard
+// that fires before the driver calls IAM. Without this guard, Swiss OTC
+// users see a cryptic "No suitable endpoint could be found" error far
+// downstream (the auth succeeds, then every service call fails because
+// the catalog is empty). The guard trades that for an actionable message.
+func TestPreCreateCheck_swissRequiresProject(t *testing.T) {
+	d := &Driver{
+		Region:    "eu-ch2",
+		AccessKey: "dummy",
+		SecretKey: "dummy",
+		// ProjectName and ProjectID deliberately empty
+	}
+	err := d.PreCreateCheck()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "project-scoped",
+		"error must explain that Swiss OTC needs a project")
+	assert.Contains(t, err.Error(), "project-name",
+		"error must tell the user which flag to set")
+}
+
+// TestPreCreateCheck_standardOTCNoProjectOK confirms the guard doesn't
+// over-reach into Standard OTC flows, where AK/SK without project is a
+// long-supported path.
+func TestPreCreateCheck_standardOTCNoProjectOK(t *testing.T) {
+	d := &Driver{
+		Region:    "eu-de",
+		AccessKey: "dummy",
+		SecretKey: "dummy",
+	}
+	err := d.PreCreateCheck()
+	// Without real IAM access the auth call will fail, but the failure
+	// must NOT be our Swiss-specific project guard — it should be a
+	// network/auth error from a later stage.
+	if err != nil {
+		assert.NotContains(t, err.Error(), "project-scoped",
+			"Standard OTC must not trigger the Swiss project guard")
+	}
+}
+
 func TestSetConfigFromFlags_explicit_authURL_wins(t *testing.T) {
 	driver := NewDriver("test-machine", "")
 

--- a/driver/regions_test.go
+++ b/driver/regions_test.go
@@ -152,6 +152,49 @@ func TestValidateAgainstRegion(t *testing.T) {
 }
 
 // TestSetConfigFromFlags_explicit_authURL_wins ensures user overrides are respected.
+// TestSetConfigFromFlags_sshAllowCIDR verifies the SDE-345 fix: the driver
+// captures the --opentelekomcloud-ssh-allow-cidr flag so that createDefaultGroup
+// can restrict port 22 ingress instead of the hardcoded 0.0.0.0/0.
+func TestSetConfigFromFlags_sshAllowCIDR(t *testing.T) {
+	const myCIDR = "203.0.113.42/32"
+
+	driver := NewDriver("test-machine", "")
+
+	flags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"opentelekomcloud-region":         "eu-ch2",
+			"opentelekomcloud-access-key":     "dummy",
+			"opentelekomcloud-secret-key":     "dummy",
+			"opentelekomcloud-ssh-allow-cidr": myCIDR,
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+	assert.NoError(t, driver.SetConfigFromFlags(flags))
+
+	assert.Equal(t, myCIDR, driver.SSHAllowCIDR,
+		"--opentelekomcloud-ssh-allow-cidr must be captured on the Driver")
+}
+
+// TestSetConfigFromFlags_sshAllowCIDR_defaultsEmpty documents that when the
+// flag is not provided, we keep the default empty (= caller falls back to
+// 0.0.0.0/0 with a warning). This preserves upstream-compatible behaviour.
+func TestSetConfigFromFlags_sshAllowCIDR_defaultsEmpty(t *testing.T) {
+	driver := NewDriver("test-machine", "")
+
+	flags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"opentelekomcloud-region":     "eu-ch2",
+			"opentelekomcloud-access-key": "dummy",
+			"opentelekomcloud-secret-key": "dummy",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+	assert.NoError(t, driver.SetConfigFromFlags(flags))
+
+	assert.Empty(t, driver.SSHAllowCIDR,
+		"absence of flag must yield empty string, not a silently-defaulted CIDR")
+}
+
 func TestSetConfigFromFlags_explicit_authURL_wins(t *testing.T) {
 	driver := NewDriver("test-machine", "")
 

--- a/driver/regions_test.go
+++ b/driver/regions_test.go
@@ -1,0 +1,156 @@
+package opentelekomcloud
+
+import (
+	"testing"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegionProfileFor_known(t *testing.T) {
+	cases := []struct {
+		region      string
+		wantAuthURL string
+		wantAZ      string
+	}{
+		{
+			region:      "eu-de",
+			wantAuthURL: "https://iam.eu-de.otc.t-systems.com/v3",
+			wantAZ:      "eu-de-01",
+		},
+		{
+			region:      "eu-nl",
+			wantAuthURL: "https://iam.eu-nl.otc.t-systems.com/v3",
+			wantAZ:      "eu-nl-01",
+		},
+		{
+			// Swiss OTC uses the iam-pub prefix and .sc. infix.
+			// A simple substitution pattern does NOT produce this — that's
+			// the entire reason this map exists.
+			region:      "eu-ch2",
+			wantAuthURL: "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3",
+			wantAZ:      "eu-ch2a",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.region, func(t *testing.T) {
+			p := RegionProfileFor(tc.region)
+			assert.Equal(t, tc.wantAuthURL, p.AuthURL)
+			assert.Equal(t, tc.wantAZ, p.DefaultAZ)
+			assert.True(t, KnownRegion(tc.region))
+		})
+	}
+}
+
+func TestRegionProfileFor_unknown_falls_back_to_standard_pattern(t *testing.T) {
+	p := RegionProfileFor("eu-xx-future")
+	assert.Equal(t, "https://iam.eu-xx-future.otc.t-systems.com/v3", p.AuthURL)
+	assert.Empty(t, p.DefaultAZ, "unknown region should not invent an AZ")
+	assert.False(t, KnownRegion("eu-xx-future"))
+}
+
+// TestSetConfigFromFlags_appliesRegionDefaults verifies the integration point:
+// setting only --opentelekomcloud-region must yield a correct AuthURL and AZ.
+func TestSetConfigFromFlags_appliesRegionDefaults(t *testing.T) {
+	driver := NewDriver("test-machine", "")
+
+	flags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"opentelekomcloud-region":      "eu-ch2",
+			"opentelekomcloud-access-key":  "dummy", // satisfy checkConfig auth requirement
+			"opentelekomcloud-secret-key":  "dummy",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+	assert.NoError(t, driver.SetConfigFromFlags(flags))
+
+	assert.Equal(t, "eu-ch2", driver.Region)
+	assert.Equal(t, "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3", driver.AuthURL,
+		"AuthURL must be derived from region profile when not set explicitly")
+	assert.Equal(t, "eu-ch2a", driver.AvailabilityZone,
+		"AZ default must come from region profile")
+}
+
+// TestValidateAgainstRegion exercises the hybrid policy: hard-error on AZ,
+// warn-only on flavor family.
+func TestValidateAgainstRegion(t *testing.T) {
+	cases := []struct {
+		name      string
+		region    string
+		az        string
+		flavor    string
+		wantError bool
+		errorHint string // substring that must appear in the error message
+	}{
+		{
+			name:   "valid eu-ch2 combo",
+			region: "eu-ch2", az: "eu-ch2a", flavor: "s3.xlarge.2",
+			wantError: false,
+		},
+		{
+			name:   "eu-ch2 with eu-de AZ is rejected",
+			region: "eu-ch2", az: "eu-de-03", flavor: "s3.xlarge.2",
+			wantError: true, errorHint: "availability zone",
+		},
+		{
+			name:   "eu-ch2 with wrong flavor family is only warned, not rejected",
+			region: "eu-ch2", az: "eu-ch2a", flavor: "s2.large.2",
+			wantError: false,
+		},
+		{
+			name:   "eu-de has no flavor restriction, any family passes",
+			region: "eu-de", az: "eu-de-01", flavor: "m3.large.2",
+			wantError: false,
+		},
+		{
+			name:   "unknown region skips all validation",
+			region: "eu-xx-future", az: "nonsense-az", flavor: "nope.xl",
+			wantError: false,
+		},
+		{
+			name:   "empty AZ is accepted (nothing to validate)",
+			region: "eu-ch2", az: "", flavor: "s3.xlarge.2",
+			wantError: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &Driver{
+				Region:           tc.region,
+				AvailabilityZone: tc.az,
+				FlavorName:       tc.flavor,
+			}
+			err := d.validateAgainstRegion()
+			if tc.wantError {
+				assert.Error(t, err)
+				if tc.errorHint != "" {
+					assert.Contains(t, err.Error(), tc.errorHint)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestSetConfigFromFlags_explicit_authURL_wins ensures user overrides are respected.
+func TestSetConfigFromFlags_explicit_authURL_wins(t *testing.T) {
+	driver := NewDriver("test-machine", "")
+
+	const customURL = "https://iam.custom.example/v3"
+
+	flags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"opentelekomcloud-region":     "eu-ch2",
+			"opentelekomcloud-auth-url":   customURL,
+			"opentelekomcloud-access-key": "dummy",
+			"opentelekomcloud-secret-key": "dummy",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+	assert.NoError(t, driver.SetConfigFromFlags(flags))
+
+	assert.Equal(t, customURL, driver.AuthURL, "explicit --auth-url must win over region default")
+}

--- a/driver/regions_test.go
+++ b/driver/regions_test.go
@@ -27,9 +27,16 @@ func TestRegionProfileFor_known(t *testing.T) {
 			// Swiss OTC uses the iam-pub prefix and .sc. infix.
 			// A simple substitution pattern does NOT produce this — that's
 			// the entire reason this map exists.
+			//
+			// AZ naming: Swiss OTC uses the same `<region>-NN` convention
+			// as Standard OTC (verified 2026-04-17 against live VMs in
+			// a CCM E2E project — OTC console shows `eu-ch2-01`).
+			// An earlier `eu-ch2a` guess was wrong; OTC silently placed
+			// the VM into a default AZ when passed the unknown name —
+			// a very quiet failure mode.
 			region:      "eu-ch2",
 			wantAuthURL: "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3",
-			wantAZ:      "eu-ch2a",
+			wantAZ:      "eu-ch2-01",
 		},
 	}
 
@@ -68,7 +75,7 @@ func TestSetConfigFromFlags_appliesRegionDefaults(t *testing.T) {
 	assert.Equal(t, "eu-ch2", driver.Region)
 	assert.Equal(t, "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3", driver.AuthURL,
 		"AuthURL must be derived from region profile when not set explicitly")
-	assert.Equal(t, "eu-ch2a", driver.AvailabilityZone,
+	assert.Equal(t, "eu-ch2-01", driver.AvailabilityZone,
 		"AZ default must come from region profile")
 }
 
@@ -85,7 +92,7 @@ func TestValidateAgainstRegion(t *testing.T) {
 	}{
 		{
 			name:   "valid eu-ch2 combo",
-			region: "eu-ch2", az: "eu-ch2a", flavor: "s3.xlarge.2",
+			region: "eu-ch2", az: "eu-ch2-01", flavor: "s3.xlarge.2",
 			wantError: false,
 		},
 		{
@@ -94,8 +101,18 @@ func TestValidateAgainstRegion(t *testing.T) {
 			wantError: true, errorHint: "availability zone",
 		},
 		{
+			name:   "eu-ch2 with old guess AZ (eu-ch2a) is rejected — regression guard",
+			region: "eu-ch2", az: "eu-ch2a", flavor: "s3.xlarge.2",
+			wantError: true, errorHint: "availability zone",
+		},
+		{
+			name:   "eu-ch2-02 is also a valid AZ",
+			region: "eu-ch2", az: "eu-ch2-02", flavor: "s3.xlarge.2",
+			wantError: false,
+		},
+		{
 			name:   "eu-ch2 with wrong flavor family is only warned, not rejected",
-			region: "eu-ch2", az: "eu-ch2a", flavor: "s2.large.2",
+			region: "eu-ch2", az: "eu-ch2-01", flavor: "s2.large.2",
 			wantError: false,
 		},
 		{

--- a/driver/regions_test.go
+++ b/driver/regions_test.go
@@ -28,15 +28,14 @@ func TestRegionProfileFor_known(t *testing.T) {
 			// A simple substitution pattern does NOT produce this — that's
 			// the entire reason this map exists.
 			//
-			// AZ naming: Swiss OTC uses the same `<region>-NN` convention
-			// as Standard OTC (verified 2026-04-17 against live VMs in
-			// a CCM E2E project — OTC console shows `eu-ch2-01`).
-			// An earlier `eu-ch2a` guess was wrong; OTC silently placed
-			// the VM into a default AZ when passed the unknown name —
-			// a very quiet failure mode.
+			// AZ names: the ECS v1 API accepts `eu-ch2a` / `eu-ch2b`, NOT
+			// `eu-ch2-01` / `eu-ch2-02` (despite what the OTC Console shows).
+			// Verified 2026-04-17 with a failing API call:
+			//   Ecs.0005: "availability_zone=eu-ch2-01 not exist"
+			// See driver/regions.go for the full investigation note.
 			region:      "eu-ch2",
 			wantAuthURL: "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3",
-			wantAZ:      "eu-ch2-01",
+			wantAZ:      "eu-ch2a",
 		},
 	}
 
@@ -75,8 +74,8 @@ func TestSetConfigFromFlags_appliesRegionDefaults(t *testing.T) {
 	assert.Equal(t, "eu-ch2", driver.Region)
 	assert.Equal(t, "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3", driver.AuthURL,
 		"AuthURL must be derived from region profile when not set explicitly")
-	assert.Equal(t, "eu-ch2-01", driver.AvailabilityZone,
-		"AZ default must come from region profile")
+	assert.Equal(t, "eu-ch2a", driver.AvailabilityZone,
+		"AZ default must come from region profile (API name, not console label)")
 }
 
 // TestValidateAgainstRegion exercises the hybrid policy: hard-error on AZ,
@@ -91,8 +90,8 @@ func TestValidateAgainstRegion(t *testing.T) {
 		errorHint string // substring that must appear in the error message
 	}{
 		{
-			name:   "valid eu-ch2 combo",
-			region: "eu-ch2", az: "eu-ch2-01", flavor: "s3.xlarge.2",
+			name:   "valid eu-ch2 combo (API AZ name)",
+			region: "eu-ch2", az: "eu-ch2a", flavor: "s3.xlarge.2",
 			wantError: false,
 		},
 		{
@@ -101,18 +100,18 @@ func TestValidateAgainstRegion(t *testing.T) {
 			wantError: true, errorHint: "availability zone",
 		},
 		{
-			name:   "eu-ch2 with old guess AZ (eu-ch2a) is rejected — regression guard",
-			region: "eu-ch2", az: "eu-ch2a", flavor: "s3.xlarge.2",
+			name: "eu-ch2 with console-style AZ (eu-ch2-01) is rejected — API accepts only eu-ch2a/b",
+			region: "eu-ch2", az: "eu-ch2-01", flavor: "s3.xlarge.2",
 			wantError: true, errorHint: "availability zone",
 		},
 		{
-			name:   "eu-ch2-02 is also a valid AZ",
-			region: "eu-ch2", az: "eu-ch2-02", flavor: "s3.xlarge.2",
+			name:   "eu-ch2b is also a valid AZ",
+			region: "eu-ch2", az: "eu-ch2b", flavor: "s3.xlarge.2",
 			wantError: false,
 		},
 		{
 			name:   "eu-ch2 with wrong flavor family is only warned, not rejected",
-			region: "eu-ch2", az: "eu-ch2-01", flavor: "s2.large.2",
+			region: "eu-ch2", az: "eu-ch2a", flavor: "s2.large.2",
 			wantError: false,
 		},
 		{

--- a/driver/retry_test.go
+++ b/driver/retry_test.go
@@ -1,0 +1,90 @@
+package opentelekomcloud
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsEOFLikeError covers both the wrapped-error path (errors.Is) and the
+// string-match fallback for errors that transports returned without wrapping.
+func TestIsEOFLikeError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not EOF", nil, false},
+		{"io.EOF direct", io.EOF, true},
+		{"io.ErrUnexpectedEOF direct", io.ErrUnexpectedEOF, true},
+		{"wrapped io.EOF", fmt.Errorf("wrapper: %w", io.EOF), true},
+		{"wrapped io.ErrUnexpectedEOF", fmt.Errorf("http: %w", io.ErrUnexpectedEOF), true},
+		{"string-only 'unexpected EOF'", errors.New("unexpected EOF"), true},
+		{"string EOF anywhere", errors.New("failed to delete: EOF on stream"), true},
+		{"arbitrary other error", errors.New("conflict: 409"), false},
+		{"empty string error", errors.New(""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isEOFLikeError(tc.err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestRetryOnEOF_successFirstTry confirms the common-path: no retry when
+// the first attempt succeeds. Sleep must NOT fire.
+func TestRetryOnEOF_successFirstTry(t *testing.T) {
+	calls := 0
+	err := retryOnEOF("noop", func() error {
+		calls++
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls, "success on first try must not retry")
+}
+
+// TestRetryOnEOF_retriesOnEOFThenSucceeds is the scenario that motivated
+// SDE-346: OTC's EIP release returns EOF on the first call, succeeds on
+// the retry. The helper must swallow the first EOF and return nil.
+func TestRetryOnEOF_retriesOnEOFThenSucceeds(t *testing.T) {
+	calls := 0
+	err := retryOnEOF("flaky", func() error {
+		calls++
+		if calls == 1 {
+			return io.ErrUnexpectedEOF
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, calls, "must retry exactly once on EOF")
+}
+
+// TestRetryOnEOF_doesNotRetryOnNonEOF prevents the helper from masking
+// unrelated failures (e.g. 409 Conflict on a double-delete).
+func TestRetryOnEOF_doesNotRetryOnNonEOF(t *testing.T) {
+	calls := 0
+	err := retryOnEOF("conflict", func() error {
+		calls++
+		return errors.New("409 Conflict")
+	})
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls, "non-EOF errors must not trigger a retry")
+	assert.Contains(t, err.Error(), "Conflict")
+}
+
+// TestRetryOnEOF_giveUpAfterTwoConsecutiveEOFs ensures we don't loop
+// forever — two strikes and we surface the error.
+func TestRetryOnEOF_giveUpAfterTwoConsecutiveEOFs(t *testing.T) {
+	calls := 0
+	err := retryOnEOF("still-broken", func() error {
+		calls++
+		return io.ErrUnexpectedEOF
+	})
+	assert.Error(t, err)
+	assert.Equal(t, 2, calls, "must give up after one retry")
+	assert.True(t, isEOFLikeError(err))
+}

--- a/driver/retry_test.go
+++ b/driver/retry_test.go
@@ -39,7 +39,7 @@ func TestIsEOFLikeError(t *testing.T) {
 // the first attempt succeeds. Sleep must NOT fire.
 func TestRetryOnEOF_successFirstTry(t *testing.T) {
 	calls := 0
-	err := retryOnEOF("noop", func() error {
+	err := retryOnEOF("noop", nil, func() error {
 		calls++
 		return nil
 	})
@@ -52,7 +52,7 @@ func TestRetryOnEOF_successFirstTry(t *testing.T) {
 // the retry. The helper must swallow the first EOF and return nil.
 func TestRetryOnEOF_retriesOnEOFThenSucceeds(t *testing.T) {
 	calls := 0
-	err := retryOnEOF("flaky", func() error {
+	err := retryOnEOF("flaky", nil, func() error {
 		calls++
 		if calls == 1 {
 			return io.ErrUnexpectedEOF
@@ -67,7 +67,7 @@ func TestRetryOnEOF_retriesOnEOFThenSucceeds(t *testing.T) {
 // unrelated failures (e.g. 409 Conflict on a double-delete).
 func TestRetryOnEOF_doesNotRetryOnNonEOF(t *testing.T) {
 	calls := 0
-	err := retryOnEOF("conflict", func() error {
+	err := retryOnEOF("conflict", nil, func() error {
 		calls++
 		return errors.New("409 Conflict")
 	})
@@ -80,11 +80,50 @@ func TestRetryOnEOF_doesNotRetryOnNonEOF(t *testing.T) {
 // forever — two strikes and we surface the error.
 func TestRetryOnEOF_giveUpAfterTwoConsecutiveEOFs(t *testing.T) {
 	calls := 0
-	err := retryOnEOF("still-broken", func() error {
+	err := retryOnEOF("still-broken", nil, func() error {
 		calls++
 		return io.ErrUnexpectedEOF
 	})
 	assert.Error(t, err)
 	assert.Equal(t, 2, calls, "must give up after one retry")
 	assert.True(t, isEOFLikeError(err))
+}
+
+// TestRetryOnEOF_resetCallbackFiresExactlyOnceOnEOF is the key SDE-346
+// invariant: the transport-reset hook must fire between attempt 1 and 2
+// whenever EOF triggers a retry. It MUST NOT fire on non-EOF errors
+// (so successful-first-try and 409-Conflict paths don't wastefully reset
+// the HTTP pool).
+func TestRetryOnEOF_resetCallbackFiresExactlyOnceOnEOF(t *testing.T) {
+	resetCalls := 0
+	fnCalls := 0
+	err := retryOnEOF("eof-with-reset", func() { resetCalls++ }, func() error {
+		fnCalls++
+		if fnCalls == 1 {
+			return io.ErrUnexpectedEOF
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, fnCalls)
+	assert.Equal(t, 1, resetCalls, "reset must run exactly once, between the two attempts")
+}
+
+func TestRetryOnEOF_resetCallbackDoesNotFireOnSuccess(t *testing.T) {
+	resetCalls := 0
+	err := retryOnEOF("happy-path", func() { resetCalls++ }, func() error {
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, resetCalls)
+}
+
+func TestRetryOnEOF_resetCallbackDoesNotFireOnNonEOFError(t *testing.T) {
+	resetCalls := 0
+	err := retryOnEOF("non-eof", func() { resetCalls++ }, func() error {
+		return errors.New("409 Conflict")
+	})
+	assert.Error(t, err)
+	assert.Equal(t, 0, resetCalls,
+		"non-EOF errors must not waste the HTTP pool by triggering a reset")
 }

--- a/driver/services/client.go
+++ b/driver/services/client.go
@@ -87,6 +87,18 @@ func (c *Client) Authenticate() error {
 	return nil
 }
 
+// CloseIdleConnections drops all idle keep-alive connections on the
+// ProviderClient's HTTP transport. Used by the driver's Remove() path
+// (SDE-346) to recover from an `unexpected EOF` that left a half-closed
+// socket in the pool — without this, the retry picks up the same dead
+// socket and fails again silently.
+func (c *Client) CloseIdleConnections() {
+	if c == nil || c.Provider == nil {
+		return
+	}
+	c.Provider.HTTPClient.CloseIdleConnections()
+}
+
 // Token - get token
 func (c *Client) Token() (string, error) {
 	if c.Provider == nil || c.Provider.Token() == "" {

--- a/driver/services/compute.go
+++ b/driver/services/compute.go
@@ -299,24 +299,33 @@ const (
 	tcpProtocol = "TCP"
 )
 
-func (c *Client) addInboundRule(secGroupID string, fromPort int, toPort int) error {
+func (c *Client) addInboundRule(secGroupID string, fromPort int, toPort int, cidr string) error {
+	if cidr == "" {
+		cidr = cidrAll
+	}
 	ruleOpts := secgroups.CreateRuleOpts{
 		ParentGroupID: secGroupID,
 		FromPort:      fromPort,
 		ToPort:        toPort,
-		CIDR:          cidrAll,
+		CIDR:          cidr,
 		IPProtocol:    tcpProtocol,
 	}
 	return secgroups.CreateRule(c.ComputeV2, ruleOpts).Err
 }
 
-// PortRange is simple sec rule port range container
+// PortRange is a sec-rule port-range container with an optional ingress CIDR.
+// CIDR empty ⇒ caller accepts the hardcoded 0.0.0.0/0 default (upstream
+// behaviour). Callers that need per-port hardening (e.g. restricting port 22
+// to prevent sshd MaxStartups drops from brute-force scanners — SDE-345)
+// should set a narrow CIDR.
 type PortRange struct {
 	From int
 	To   int
+	CIDR string
 }
 
-// CreateSecurityGroup creates new sec group and returns group ID
+// CreateSecurityGroup creates new sec group and returns group ID.
+// Each PortRange's CIDR (or 0.0.0.0/0 when empty) is applied to that port only.
 func (c *Client) CreateSecurityGroup(securityGroupName string, ports ...PortRange) (*secgroups.SecurityGroup, error) {
 	opts := secgroups.CreateOpts{
 		Name:        securityGroupName,
@@ -330,7 +339,7 @@ func (c *Client) CreateSecurityGroup(securityGroupName string, ports ...PortRang
 		if port.To == 0 {
 			port.To = port.From
 		}
-		if err := c.addInboundRule(sg.ID, port.From, port.To); err != nil {
+		if err := c.addInboundRule(sg.ID, port.From, port.To, port.CIDR); err != nil {
 			return nil, err
 		}
 	}

--- a/driver/utils.go
+++ b/driver/utils.go
@@ -26,7 +26,13 @@ const (
 	defaultSecurityGroup    = "docker-machine-grp"
 	defaultAZ               = "eu-de-01"
 	defaultFlavor           = "s3.xlarge.2"
-	defaultImage            = "Standard_Ubuntu_24.04_amd64_uefi_latest"
+	// Ubuntu 22.04 chosen as default over 24.04 UEFI:
+	//   - matches the existing rke2-sotc-cloud-manager CCM E2E test images
+	//     (2026-04-17 — homogeneous images across sister projects)
+	//   - Ubuntu 24 UEFI on Swiss OTC has shown post-create cloud-init SSH
+	//     drops (tracked in SDE-345); Ubuntu 22 is the stable baseline for
+	//     the driver's current cloud-init handshake.
+	defaultImage = "Standard_Ubuntu_22.04_latest"
 	defaultSSHUser          = "ubuntu"
 	defaultSSHPort          = 22
 	defaultRegion           = "eu-de"


### PR DESCRIPTION
**Status:** Draft — opens the conversation on upstreaming Swiss OTC (`eu-ch2`) support and three Phase-4-validated bug fixes from the [Wolfslight-Forgehouse/rke2-sotc-node-driver](https://github.com/Wolfslight-Forgehouse/rke2-sotc-node-driver) fork.

## What changed (17 commits ahead of upstream/devel)

### Functional fixes (consider cherry-picking even if Swiss OTC support is not merged)

- **SDE-345** — `--opentelekomcloud-ssh-allow-cidr` flag restricts default-SG SSH ingress. Default `0.0.0.0/0` is a security footgun; this lets operators pin to an ops CIDR while preserving the zero-config path.
- **SDE-346** — `Remove()` ordering + HTTP transport retry:
  - EIP release moved to LAST in teardown (was before `deleteInstance`, causing orphaned EIPs on the common instance-delete timeout path).
  - Retry on `unexpected EOF` during HTTP GET with a fresh transport — OTC's edge occasionally resets long-running connections mid-body.
- **SDE-388** — Default VPC/subnet/SG names qualified by machine name. Multiple cross-project or cross-region `docker-machine create` runs no longer collide on a single "default-vpc" that's region-scoped.

### Swiss OTC (`eu-ch2`) multi-region support

- Region profile map with correct AZ naming (`eu-ch2a`/`eu-ch2b`) — Swiss OTC API doesn't use the console's `eu-ch2-01/02` labels.
- IAM endpoint `iam-pub.eu-ch2.sc.otc.t-systems.com/v3` (note the `.sc.` infix + `iam-pub` prefix) and regional service endpoints.
- Ubuntu 22.04 as default image (Ubuntu 18.04 EOL, 20.04 no longer in Swiss OTC catalog).

### Phase 4 Documentation (`docs/phase4/`)

- `01-standalone-driver-test.md` — manual smoke test against a fresh eu-ch2 project
- `02-rancher-integration-test.md` — Rancher UI + node driver flow
- `03-regression-checklist.md` — what to re-run when bumping releases
- `scripts/` — reproducible smoke test + orphan audit
- Session notes documenting the SDE-346 root cause + validation

## Why

Swiss OTC (`eu-ch2`) differs from Standard OTC (`eu-de`, `eu-nl`) in three ways upstream doesn't currently handle:
1. IAM endpoint hostname is not pattern-substitutable (`iam-pub.eu-ch2.sc...` vs `iam.eu-de...`)
2. AZ naming is `eu-ch2a/b`, not `eu-ch2-01/02/03`
3. Flavor catalog is s3-family only; Ubuntu image names differ

The upstream driver is excellent — these changes are additive.

## Risk / review notes

- Region-profile map is data-only; no behavior change for existing `eu-de` users.
- SDE-345 flag is opt-in (default behavior unchanged). New users learn about it via `--help`.
- SDE-346 ordering fix is a straight correctness improvement — current order leaks EIPs.
- SDE-388 qualified names will look slightly different in `openstack` listings for fresh runs. Existing projects' resources are untouched (resource IDs, not names, are what docker-machine tracks).

## What's validated

- Real cluster creation + deletion against `eu-ch2_wotest` project (Phase 4 docs capture the test run, v2.1.0-sotc.2 tag).
- SDE-346 validated: EIP cleanup reliably completes even when instance-delete times out.
- SDE-345 validated: `--ssh-allow-cidr 1.2.3.4/32` correctly restricts the SG rule.

## Not included in this PR

- Docs linking to `rke2-sotc-infra` (sibling repo, separate Terraform path).
- The Rancher UI extension fork (`rke2-sotc-node-driver-ui`, separate PR if desired).

## Open to feedback

Happy to split this into smaller PRs if the maintainers prefer (e.g. SDE-346 alone, then SDE-345, then region profile map). Draft intentionally — awaiting maintainer input on scope + style.